### PR TITLE
Remove DSum and DMap Aeson instances

### DIFF
--- a/common/Data/Aeson/GADT.hs
+++ b/common/Data/Aeson/GADT.hs
@@ -46,8 +46,12 @@ conArity c = case c of
   GadtC _ ts _ -> length ts
   RecGadtC _ ts _ -> length ts
 
+{-# DEPRECATED deriveGADTInstances "Use deriveJSONGADT instead" #-}
 deriveGADTInstances :: Name -> DecsQ
-deriveGADTInstances n = do
+deriveGADTInstances = deriveJSONGADT
+
+deriveJSONGADT :: Name -> DecsQ
+deriveJSONGADT n = do
   tj <- deriveToJSONGADT n
   fj <- deriveFromJSONGADT n
   eqt <- deriveEqTag n

--- a/common/rhyolite-common.cabal
+++ b/common/rhyolite-common.cabal
@@ -18,7 +18,6 @@ library
     , base
     , bytestring
     , constraints
-    , constraints-extras
     , containers
     , data-default
     , dependent-sum


### PR DESCRIPTION
Users should import the better instances from https://github.com/obsidiansystems/dependent-sum-aeson-orphans instead.

cc @cgibbard