### PR TITLE
frontend-forms: Make the validation function Behavior -> BehaviorValidation --- blocked on #49

### DIFF
--- a/frontend/Rhyolite/Frontend/Form.hs
+++ b/frontend/Rhyolite/Frontend/Form.hs
@@ -14,6 +14,7 @@ module Rhyolite.Frontend.Form where
 import Control.Lens ((%~), makeLenses, preview)
 import Control.Monad
 import Control.Monad.Except
+import Data.Bifunctor
 import Data.Functor.Compose
 import Data.Map (Map)
 import Data.Text (Text)
@@ -75,10 +76,16 @@ newtype DynValidation t e a = DynValidation { unDynValidation :: Compose (Dynami
 deriving instance Reflex t => Functor (DynValidation t e)
 deriving instance (Reflex t, Semigroup e) => Applicative (DynValidation t e)
 
+instance Reflex t => Bifunctor (DynValidation t) where
+  bimap f g (DynValidation (Compose v)) = DynValidation $ Compose $ bimap f g <$> v
+
 newtype BehaviorValidation t e a = BehaviorValidation { unBehaviorValidation :: Compose (Behavior t) (Validation e) a }
 
 deriving instance Reflex t => Functor (BehaviorValidation t e)
 deriving instance (Reflex t, Semigroup e) => Applicative (BehaviorValidation t e)
+
+instance Reflex t => Bifunctor (BehaviorValidation t) where
+  bimap f g (BehaviorValidation (Compose v)) = BehaviorValidation $ Compose $ bimap f g <$> v
 
 fromDynValidation :: Reflex t => DynValidation t e a -> Dynamic t (Either e a)
 fromDynValidation (DynValidation (Compose v)) = toEither <$> v

--- a/frontend/Rhyolite/Frontend/Form.hs
+++ b/frontend/Rhyolite/Frontend/Form.hs
@@ -136,19 +136,18 @@ manageValidation validator renderInput = do
 guardEither :: e -> Bool -> Either e ()
 guardEither e cond = if cond then Right () else Left e
 
-validateEmail :: Text -> Either Text Text
-validateEmail m = do
-  ne <- validateNonEmpty m
-  case T.breakOn "@" ne of
-    (_, xs) | T.length xs > 1 -> return ne
-    _ -> throwError "Invalid email"
-
-validateNonEmpty :: Text -> Either Text Text
+validateNonEmpty :: Text -> Either () Text
 validateNonEmpty m = do
   let txt = T.strip m
-  case T.null txt of
-    True -> throwError "Is empty"
-    False -> return txt
+  guardEither () $ not $ T.null txt
+  return txt
+
+validateEmail :: Text -> Either () Text
+validateEmail m = do
+  ne <- validateNonEmpty m
+  let (_, xs) = T.breakOn "@" ne
+  guardEither () $ T.length xs > 1
+  return ne
 
 data ValidationConfig t m e a = ValidationConfig
   { _validationConfig_feedback :: Either (Dynamic t e) (Dynamic t a) -> m ()

--- a/frontend/Rhyolite/Frontend/Form.hs
+++ b/frontend/Rhyolite/Frontend/Form.hs
@@ -209,10 +209,8 @@ validationInput config = do
           inputAttrs = ffor eValidated $ \case
             Left _ -> fmap Just $ _validationConfig_invalidAttributes config
             Right _ -> fmap Just $ _validationConfig_validAttributes config
-  let bValidated = current $ fromDynValidation dValidated
-  dValidatedGated <- fmap toDynValidation $ buildDynamic (sample bValidated) eValidated
-  val <- eitherDyn $ fromDynValidation dValidatedGated
+  val <- eitherDyn $ fromDynValidation dValidated
   dyn_ $ _validationConfig_feedback config <$> val
-  return $ ValidationInput input dValidatedGated
+  return $ ValidationInput input dValidated
 
 makeLenses ''ValidationConfig

--- a/frontend/Rhyolite/Frontend/Form.hs
+++ b/frontend/Rhyolite/Frontend/Form.hs
@@ -133,6 +133,9 @@ manageValidation validator renderInput = do
   validatedInput <- weirdMap (fromBehaviorValidation . validator) $ value input
   return (input, toDynValidation validatedInput)
 
+guardEither :: e -> Bool -> Either e ()
+guardEither e cond = if cond then Right () else Left e
+
 validateEmail :: Text -> Either Text Text
 validateEmail m = do
   ne <- validateNonEmpty m


### PR DESCRIPTION
This allows validation to take external state into account. Validation can pull external state, but never be pushed by it, as the validations make clear.