### PR TITLE
Point back to upstream version of monoidal-containers

### DIFF
--- a/datastructures/src/Rhyolite/Map/Monoidal.hs
+++ b/datastructures/src/Rhyolite/Map/Monoidal.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 module Rhyolite.Map.Monoidal (module X, (=:), restrictKeys) where
 
-import Data.Align
 import Data.AppendMap as X
 import Data.Map.Monoidal as X
 
@@ -17,7 +16,3 @@ infixr 7 =:
 -- TODO: Use built-in implementation after upgrading 'containers'.
 restrictKeys :: Ord k => MonoidalMap k a -> Set.Set k -> MonoidalMap k a
 restrictKeys m ks = filterWithKey (\k _ -> k `Set.member` ks) m
-
-#if !(MIN_VERSION_monoidal_containers(0,4,1))
-deriving instance Ord k => Align (MonoidalMap k)
-#endif

--- a/default.nix
+++ b/default.nix
@@ -26,6 +26,15 @@ let
       sha256 = "103fqr710pddys3bqz4d17skgqmwiwrjksn2lbnc3w7s01kal98a";
     };
 
+    # Reflex needs monoidal-containers 0.4.0.0 but that is not
+    # available to some older Obelisk versions.
+    monoidal-containers = pkgs.fetchFromGitHub {
+      owner = "bgamari";
+      repo = "monoidal-containers";
+      rev = "a34c9fbe191725ef9a9c7783e103c24796bd91e3";
+      sha256 = "1ar2w4rx0mh4nvwzpc125l3hj9xslargl43vnssmh9l6ynhi8ksv";
+    };
+
     # New version, recently added to hackage
     constraints-extras = pkgs.fetchFromGitHub {
       owner = "obsidiansystems";

--- a/default.nix
+++ b/default.nix
@@ -26,8 +26,7 @@ let
       sha256 = "103fqr710pddys3bqz4d17skgqmwiwrjksn2lbnc3w7s01kal98a";
     };
 
-    # Reflex needs monoidal-containers 0.4.0.0 but that is not
-    # available to some older Obelisk versions.
+    # Unreleased version, includes fromList = fromListWith (<>)
     monoidal-containers = pkgs.fetchFromGitHub {
       owner = "bgamari";
       repo = "monoidal-containers";


### PR DESCRIPTION
to a version that includes a better fromList