### PR TITLE
Fix missing dependency for gargoyle-postgresql-nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -50,6 +50,7 @@ let
     (self: super: {
       bytestring-trie = haskellLib.dontCheck super.bytestring-trie;
       validation = haskellLib.dontCheck super.validation;
+      gargoyle-postgresql-nix = haskellLib.overrideCabal super.gargoyle-postgresql-nix { librarySystemDepends = [ nixpkgs.postgresql ]; };
     })
   ];
 


### PR DESCRIPTION
gargoyle-postgresql-nix uses staticWhich to find postgresql executables
at build time, so we need to supply it; it's not represented in the
cabal file.