### PR TITLE
generalize =:

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,10 @@
 
 This project's release branch is `master`. This log is written from the perspective of the release branch: when changes hit `master`, they are considered released, and the date should reflect that release.
 
+## 2019-08-24 - Unreleased
+
+* Generalized `=:` from `MonoidalMap` to any [`At s`](http://hackage.haskell.org/package/lens-4.17.1/docs/Control-Lens-At.html#t:At)
+
 ## 2019-08-19 - Unreleased
 
 * Added `standardPipeline` as a good example of a last argument you can use for serveDbOverWebsockets, in the case that you have a Functor-style query/view type. It now uses condense/disperse from the Vessel library.

--- a/datastructures/src/Rhyolite/Map/Monoidal.hs
+++ b/datastructures/src/Rhyolite/Map/Monoidal.hs
@@ -3,14 +3,16 @@
 {-# LANGUAGE StandaloneDeriving #-}
 module Rhyolite.Map.Monoidal (module X, (=:), restrictKeys) where
 
+import Control.Lens (At, Index, IxValue, set, at)
 import Data.AppendMap as X
 import Data.Map.Monoidal as X
 
 import qualified Data.Set as Set
 
 -- | Operator for creating a singleton 'Map'
-(=:) :: k -> a -> MonoidalMap k a
-k =: v = singleton k v
+(=:) :: (Monoid s, At s) => Index s -> IxValue s -> s
+k =: v = set (at k) (Just v) mempty
+{-# INLINE (=:) #-}
 infixr 7 =:
 
 -- TODO: Use built-in implementation after upgrading 'containers'.


### PR DESCRIPTION
generalize the `=:` operator as used in `Reflex` and so on to any map-like container (specifically, `At s` http://hackage.haskell.org/package/lens-4.17.1/docs/Control-Lens-At.html#t:At )