### PR TITLE
Remove some warnings from incorrect option flags

### DIFF
--- a/aeson-orphans/rhyolite-aeson-orphans.cabal
+++ b/aeson-orphans/rhyolite-aeson-orphans.cabal
@@ -24,4 +24,4 @@ library
   exposed-modules: Rhyolite.Aeson.Orphans
 
   other-extensions: TemplateHaskell
-  ghc-options: -threaded -Wall -fno-warn-unused-do-bind -fwarn-tabs -funbox-strict-fields -O2 -fprof-auto-calls -rtsopts
+  ghc-options: -Wall -fno-warn-unused-do-bind -fwarn-tabs -funbox-strict-fields -O2 -fprof-auto-calls

--- a/backend/rhyolite-backend.cabal
+++ b/backend/rhyolite-backend.cabal
@@ -88,4 +88,4 @@ library
   other-extensions: TemplateHaskell
   ghc-options: -Wall -fno-warn-unused-do-bind -fwarn-tabs -funbox-strict-fields -O2 -fprof-auto-calls
   if flag(support-systemd-journal) && os(linux)
-    ghc-options: -DSUPPORT_SYSTEMD_JOURNAL
+    cpp-options: -DSUPPORT_SYSTEMD_JOURNAL

--- a/datastructures/rhyolite-datastructures.cabal
+++ b/datastructures/rhyolite-datastructures.cabal
@@ -29,4 +29,4 @@ library
     Rhyolite.SemiMap
 
   other-extensions: TemplateHaskell
-  ghc-options: -threaded -Wall -fno-warn-unused-do-bind -fwarn-tabs -funbox-strict-fields -O2 -fprof-auto-calls -rtsopts
+  ghc-options: -Wall -fno-warn-unused-do-bind -fwarn-tabs -funbox-strict-fields -O2 -fprof-auto-calls

--- a/frontend/rhyolite-frontend.cabal
+++ b/frontend/rhyolite-frontend.cabal
@@ -71,4 +71,4 @@ library
     Rhyolite.Frontend.Modal.Class
     Rhyolite.Frontend.Widget
 
-  ghc-options: -Wall -fno-warn-unused-do-bind -fwarn-tabs -funbox-strict-fields -O2 -fprof-auto-calls -rtsopts -fexpose-all-unfoldings
+  ghc-options: -Wall -fno-warn-unused-do-bind -fwarn-tabs -funbox-strict-fields -O2 -fprof-auto-calls -fexpose-all-unfoldings


### PR DESCRIPTION
```shell
$ nix-shell -A proj.shells.ghc --run 'cabal new-repl lib:rhyolite-backend'
Build profile: -w ghc-8.4.3 -O1
In order, the following will be built (use -v for more details):
 - rhyolite-aeson-orphans-0.1 (lib:rhyolite-aeson-orphans) (first run)
 - rhyolite-common-0.1 (lib:rhyolite-common) (first run)
 - rhyolite-datastructures-0.1 (lib:rhyolite-datastructures) (configuration changed)
 - rhyolite-backend-db-0.1 (lib:rhyolite-backend-db) (configuration changed)
 - rhyolite-backend-0.1 (configuration changed)
Preprocessing library for rhyolite-aeson-orphans-0.1..
Building library for rhyolite-aeson-orphans-0.1..
Preprocessing library for rhyolite-common-0.1..
Building library for rhyolite-common-0.1..
ignoring (possibly broken) abi-depends field for packages
Configuring rhyolite-datastructures-0.1...
==> Warning: 'ghc-options: -threaded' has no effect for libraries. It should only be used for executables.
==> Warning: 'ghc-options: -rtsopts' has no effect for libraries. It should only be used for executables.
Preprocessing library for rhyolite-datastructures-0.1..
Building library for rhyolite-datastructures-0.1..
ignoring (possibly broken) abi-depends field for packages
Configuring rhyolite-backend-db-0.1...
ignoring (possibly broken) abi-depends field for packages
Preprocessing library for rhyolite-backend-db-0.1..
Building library for rhyolite-backend-db-0.1..
ignoring (possibly broken) abi-depends field for packages
Configuring rhyolite-backend-0.1...
==> Warning: Instead of 'ghc-options: -DSUPPORT_SYSTEMD_JOURNAL' use 'cpp-options:-DSUPPORT_SYSTEMD_JOURNAL'
```