### PR TITLE
Db taskworker failure reporting

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,11 @@
 
 This project's release branch is `master`. This log is written from the perspective of the release branch: when changes hit `master`, they are considered released, and the date should reflect that release.
 
+## 2019-08-31 - Unreleased
+
+* Enhances `taskWorker` and `Task` with extra fields that contain the time the job started and the error the job failed with should in case it fails.
+* Added `withSavepoint` to use SQL savepoints.
+
 ## 2019-08-19 - Unreleased
 
 * Added `standardPipeline` as a good example of a last argument you can use for serveDbOverWebsockets, in the case that you have a Functor-style query/view type. It now uses condense/disperse from the Vessel library.

--- a/common/Rhyolite/Schema/Task.hs
+++ b/common/Rhyolite/Schema/Task.hs
@@ -3,6 +3,7 @@ module Rhyolite.Schema.Task where
 
 import Data.Aeson
 import Data.Text (Text)
+import Data.Time (UTCTime)
 import GHC.Generics
 
 -- | A value in the database whose presence indicates that some external work
@@ -10,6 +11,8 @@ import GHC.Generics
 data Task a = Task
   { _task_result :: !(Maybe a)
   , _task_checkedOutBy :: !(Maybe Text) -- The backend node that has checked out this task --TODO: Use session IDs instead of Text
+  , _task_checkedOutAt :: !(Maybe UTCTime)
+  , _task_failed :: !(Maybe Text)
   }
   deriving (Show, Read, Eq, Ord, Generic)
 
@@ -20,4 +23,6 @@ empty :: Task a
 empty = Task
   { _task_result = Nothing
   , _task_checkedOutBy = Nothing
+  , _task_checkedOutAt = Nothing
+  , _task_failed = Nothing
   }


### PR DESCRIPTION
This PR Adds some fields to Task to include the error message should an exception be thrown during a task, and a Date column for the time that the job was checked out.