### PR TITLE
Be nice to bad ViewSelectors that don't filter out 0s

### DIFF
--- a/frontend/Rhyolite/Frontend/App.hs
+++ b/frontend/Rhyolite/Frontend/App.hs
@@ -74,7 +74,7 @@ functorToWire
      , QueryResult (q SelectedCount) ~ v SelectedCount)
   => QueryMorphism (q SelectedCount) (q ())
 functorToWire = QueryMorphism
-  { _queryMorphism_mapQuery = mapMaybe (\n -> if n < 0 then Nothing else Just ())
+  { _queryMorphism_mapQuery = mapMaybe (\n -> if n <= 0 then Nothing else Just ())
   , _queryMorphism_mapQueryResult = fmap (const (SelectedCount 1))
   }
 


### PR DESCRIPTION
Maybe we just need to use `error` here instead?? This was fun to track down. But obviously I have some bad group instances lying around (looking at you `MonoidalMap` cc @danbornside who complains about this rightly)