### PR TITLE
Add vessel data structures for authentication

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,10 @@ This project's release branch is `master`. This log is written from the perspect
   * Update widget emails for newer routes.
   * Use a record for email configuration.
   * Add a function for email with a StaticWidget
+* Simple authenticated queries
+  * `ErrorV` vessel captures logic for possibly failing queries
+  * `AuthMapV` gathers queries associated to different identities so that they can be processed together.
+  * `AuthenticatedV` distinguishes between public queries that need no authentication and private queries which do.
 
 ## 2020-04-28
 

--- a/backend/Rhyolite/Backend/Account.hs
+++ b/backend/Rhyolite/Backend/Account.hs
@@ -80,7 +80,7 @@ makeDefaultKeyIdInt64 ''Account 'AccountKey
 migrateAccount :: PersistBackend m => TableAnalysis m -> Migration m
 migrateAccount tableInfo = migrate tableInfo (undefined :: Account)
 
--- Returns whether a new account had to be created
+-- | Returns whether a new account had to be created
 ensureAccountExists
   :: ( PersistBackend m
      , SqlDb (PhantomDb m)
@@ -105,7 +105,7 @@ ensureAccountExists nm email = do
           notify NotificationType_Insert nm aid'
           return (True, aid')
 
--- Creates account if it doesn't already exist and sends pw email
+-- | Creates account if it doesn't already exist and sends pw email
 ensureAccountExistsEmail
   :: ( PersistBackend m, MonadBase Serializable m
      , MonadSign m, SigningKey m ~ CS.Key
@@ -122,8 +122,8 @@ ensureAccountExistsEmail
   -> m (Bool, Id Account)
 ensureAccountExistsEmail n = ensureAccountExistsEmail' (ensureAccountExists n)
 
--- Creates account if it doesn't already exist and sends pw email
--- Allows the option for a custom "ensure account" creation function
+-- | Creates account if it doesn't already exist and sends pw email Allows the
+-- option for a custom "ensure account" creation function
 ensureAccountExistsEmail'
   :: ( PersistBackend m, MonadBase Serializable m
      , MonadSign m, SigningKey m ~ CS.Key

--- a/common/Rhyolite/Vessel/AuthMapV.hs
+++ b/common/Rhyolite/Vessel/AuthMapV.hs
@@ -1,0 +1,142 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+module Rhyolite.Vessel.AuthMapV where
+
+import Data.Aeson
+import Data.Constraint.Extras
+import Data.Maybe
+import qualified Data.Map.Monoidal as MMap
+import Data.Patch
+import Data.Semigroup
+import qualified Data.Set as Set
+import Data.Vessel
+import Data.Vessel.SubVessel
+import Data.Vessel.Vessel
+import Data.Witherable
+import GHC.Generics
+import Reflex.Query.Class
+
+import Rhyolite.App
+import Rhyolite.Vessel.ErrorV
+
+-- | A functor parametric container whose data is indexed by an authentication identity
+-- where the result for each identity may succeed or fail.
+newtype AuthMapV auth v g = AuthMapV { unAuthMapV :: SubVessel auth (ErrorV () v) g }
+  deriving (Generic)
+
+deriving instance (Ord auth, Eq (view g), Eq (g (First (Maybe ())))) => Eq (AuthMapV auth view g)
+
+instance (Ord auth, ToJSON auth, ToJSON (g (First (Maybe ()))), ToJSON (view g)) => ToJSON (AuthMapV auth view g)
+instance (Ord auth, FromJSON auth, View view, FromJSON (g (First (Maybe ()))), FromJSON (view g)) => FromJSON (AuthMapV auth view g)
+
+deriving instance
+  ( Ord auth
+  , Has' Semigroup (ErrorVK () v) (FlipAp g)
+  , View v
+  ) => Semigroup (AuthMapV auth v g)
+
+deriving instance
+  ( Ord auth
+  , Has' Semigroup (ErrorVK () v) (FlipAp g)
+  , View v
+  ) => Monoid (AuthMapV auth v g)
+
+deriving instance
+  ( Ord auth
+  , Has' Group (ErrorVK () v) (FlipAp g)
+  , View v
+  ) => Group (AuthMapV auth v g)
+
+deriving instance
+  ( Ord auth
+  , Has' Additive (ErrorVK () v) (FlipAp g)
+  , View v
+  ) => Additive (AuthMapV auth v g)
+
+deriving instance (Ord auth, PositivePart (g (First (Maybe ()))), PositivePart (v g)) => PositivePart (AuthMapV auth v g)
+
+instance (Ord auth, View v) => View (AuthMapV auth v)
+instance (Ord auth, View v) => EmptyView (AuthMapV auth v) where
+  emptyV = AuthMapV emptyV
+
+instance
+  ( Ord auth
+  , Semigroup (v Identity)
+  , View v
+  , QueryResult (v Proxy) ~ v Identity
+  ) => Query (AuthMapV auth v Proxy) where
+  type QueryResult (AuthMapV auth v Proxy) = AuthMapV auth v Identity
+  crop (AuthMapV s) (AuthMapV r) = AuthMapV $ crop s r
+
+instance
+  ( Ord auth
+  , Semigroup (v Identity)
+  , View v
+  , QueryResult (v (Const ())) ~ v Identity
+  ) => Query (AuthMapV auth v (Const ())) where
+  type QueryResult (AuthMapV auth v (Const ())) = AuthMapV auth v Identity
+  crop (AuthMapV s) (AuthMapV r) = AuthMapV $ crop s r
+
+instance
+  ( Ord auth
+  , Semigroup (v Identity)
+  , View v
+  , QueryResult (v (Const SelectedCount)) ~ v Identity
+  ) => Query (AuthMapV auth v (Const SelectedCount)) where
+  type QueryResult (AuthMapV auth v (Const SelectedCount)) = AuthMapV auth v Identity
+  crop (AuthMapV s) (AuthMapV r) = AuthMapV $ crop s r
+
+instance
+  ( Ord auth
+  , View v
+  , Has' Semigroup (ErrorVK () v) (FlipAp (Compose c (VesselLeafWrapper (QueryResult (Vessel (SubVesselKey auth (ErrorV () v)) g)))))
+  , Query (Vessel (SubVesselKey auth (ErrorV () v)) g)
+  ) => Query (AuthMapV auth v (Compose c g)) where
+  type QueryResult (AuthMapV auth v (Compose c g)) = AuthMapV auth v (Compose c (VesselLeafWrapper (QueryResult (Vessel (SubVesselKey auth (ErrorV () v)) g))))
+  crop (AuthMapV s) (AuthMapV r) = AuthMapV $ crop s r
+
+-- | Given a way to verify that a token corresponds to a valid identity and
+-- a way to handle queries whose result does not depend on the particular
+-- identity making the query, handles each query efficiently while
+-- distributing the results only to valid identities.
+--
+-- token is typically like 'Signed (AuthToken Identity)'
+-- user is typically 'Id Account', iso to 'AuthToken Identity'
+handleAuthMapQuery
+  :: (Monad m, Ord token, View v)
+  => (token -> m (Maybe user))
+  -- ^ How to figure out the identity corresponding to a token
+  -> (v Proxy -> m (v Identity))
+  -- ^ Handle the aggregate query for all identities
+  -> AuthMapV token v Proxy
+  -- ^ Private views parameterized by tokens
+  -> m (AuthMapV token v Identity)
+handleAuthMapQuery readToken handler (AuthMapV vt) = do
+  let unfilteredVt = getSubVessel vt
+      unvalidatedTokens = MMap.keys unfilteredVt
+  validTokens <- Set.fromList <$> witherM (\t -> pure t <$ readToken t) unvalidatedTokens
+  let filteredVt = MMap.intersectionWith const unfilteredVt (MMap.fromSet (\_ -> ()) validTokens)
+      invalidTokens = MMap.fromSet (\_ -> failureErrorV ()) $
+        Set.difference (Set.fromList unvalidatedTokens) validTokens
+      v = condenseV filteredVt
+  v' <- disperseV . fromMaybe emptyV <$> mapDecomposedV (buildErrorV (fmap Right . handler)) v
+  -- The use of mapDecomposedV guarantees that the valid and invalid token sets are disjoint
+  pure $ AuthMapV $ mkSubVessel $ MMap.unionWith const invalidTokens v'
+
+-- | A query morphism that takes a view for a single identity and lifts it to
+-- a map of identities to views.
+authMapQueryMorphism
+  :: (Ord token, View v)
+  => token
+  -> QueryMorphism
+       (ErrorV () v (Const SelectedCount))
+       (AuthMapV token v (Const SelectedCount))
+authMapQueryMorphism token = QueryMorphism
+  { _queryMorphism_mapQuery = AuthMapV . singletonSubVessel token
+  , _queryMorphism_mapQueryResult = maybe emptyV id . lookupSubVessel token . unAuthMapV
+  }
+

--- a/common/Rhyolite/Vessel/AuthenticatedV.hs
+++ b/common/Rhyolite/Vessel/AuthenticatedV.hs
@@ -1,0 +1,157 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+module Rhyolite.Vessel.AuthenticatedV where
+
+import Data.Aeson
+import Data.Aeson.GADT.TH
+import Data.Constraint
+import Data.Constraint.Extras
+import Data.GADT.Compare
+import Data.Patch
+import Data.Type.Equality
+import Data.Vessel
+import Data.Vessel.Vessel
+import GHC.Generics
+import Reflex.Query.Class
+
+import Rhyolite.Vessel.AuthMapV
+
+-- | An internal key type used to glue together parts of a view selector
+-- that have different authentication contexts.
+data AuthenticatedVKey public private (x :: (* -> *) -> *) where
+  AuthenticatedVKey_Public :: AuthenticatedVKey public private public
+  AuthenticatedVKey_Private :: AuthenticatedVKey public private private
+
+deriveJSONGADT ''AuthenticatedVKey
+
+instance GEq (AuthenticatedVKey public private) where
+  geq = \case
+    AuthenticatedVKey_Public -> \case
+      AuthenticatedVKey_Public -> Just Refl
+      AuthenticatedVKey_Private -> Nothing
+    AuthenticatedVKey_Private -> \case
+      AuthenticatedVKey_Public -> Nothing
+      AuthenticatedVKey_Private -> Just Refl
+
+instance GCompare (AuthenticatedVKey public private) where
+  gcompare = \case
+    AuthenticatedVKey_Public -> \case
+      AuthenticatedVKey_Public -> GEQ
+      AuthenticatedVKey_Private -> GLT
+    AuthenticatedVKey_Private -> \case
+      AuthenticatedVKey_Public -> GGT
+      AuthenticatedVKey_Private -> GEQ
+
+instance ArgDict c (AuthenticatedVKey public private) where
+  type ConstraintsFor (AuthenticatedVKey public private) c = (c public, c private)
+  argDict = \case
+    AuthenticatedVKey_Public -> Dict
+    AuthenticatedVKey_Private -> Dict
+
+-- | A functor-parametric container that has a public part and a private part.
+newtype AuthenticatedV public private g = AuthenticatedV
+  { unAuthenticatedV :: Vessel (AuthenticatedVKey public private) g
+  } deriving (Generic, Eq, ToJSON, FromJSON, Semigroup, Monoid, Group, Additive)
+
+instance (View public, View private) => View (AuthenticatedV public private)
+
+instance (View public, View private) => EmptyView (AuthenticatedV public private) where
+  emptyV = AuthenticatedV emptyV
+
+instance
+  ( Semigroup (public Identity)
+  , Semigroup (private Identity)
+  , View public, View private
+  , QueryResult (private Proxy) ~ private Identity
+  ) => Query (AuthenticatedV public private Proxy) where
+  type QueryResult (AuthenticatedV public private Proxy) = AuthenticatedV public private Identity
+  crop (AuthenticatedV s) (AuthenticatedV r) = AuthenticatedV $ crop s r
+
+instance
+  ( Semigroup (public Identity)
+  , Semigroup (private Identity)
+  , View public, View private
+  , QueryResult (private (Const ())) ~ private Identity
+  ) => Query (AuthenticatedV public private (Const ())) where
+  type QueryResult (AuthenticatedV public private (Const ())) = AuthenticatedV public private Identity
+  crop (AuthenticatedV s) (AuthenticatedV r) = AuthenticatedV $ crop s r
+
+instance
+  ( Semigroup (public Identity)
+  , Semigroup (private Identity)
+  , View public, View private
+  , QueryResult (private (Const SelectedCount)) ~ private Identity
+  ) => Query (AuthenticatedV public private (Const SelectedCount)) where
+  type QueryResult (AuthenticatedV public private (Const SelectedCount)) = AuthenticatedV public private Identity
+  crop (AuthenticatedV s) (AuthenticatedV r) = AuthenticatedV $ crop s r
+
+instance
+  ( View public, View private
+  , Semigroup (private (Compose c (VesselLeafWrapper (QueryResult (Vessel (AuthenticatedVKey public private) g)))))
+  , Semigroup (public (Compose c (VesselLeafWrapper (QueryResult (Vessel (AuthenticatedVKey public private) g)))))
+  , Query (Vessel (AuthenticatedVKey public private) g)
+  ) => Query (AuthenticatedV public private (Compose c (g :: * -> *))) where
+  type QueryResult (AuthenticatedV public private (Compose c g)) = AuthenticatedV public private
+         (Compose c (VesselLeafWrapper (QueryResult (Vessel (AuthenticatedVKey public private) g))))
+  crop (AuthenticatedV s) (AuthenticatedV r) = AuthenticatedV $ crop s r
+
+-- | Given a handler for each partial view container, produces
+-- a handler for the total view container.
+handleAuthenticatedQuery'
+  :: (Monad m, View public, View private)
+  => (public Proxy -> m (public Identity))
+  -- ^ Handle the aggregate public query
+  -> (private Proxy -> m (private Identity))
+  -- ^ Handle the aggregate private query for all identities
+  -> AuthenticatedV public private Proxy
+  -- ^ Private views parameterized by tokens
+  -> m (AuthenticatedV public private Identity)
+handleAuthenticatedQuery' public private (AuthenticatedV q) = fmap AuthenticatedV $ buildV q $ \case
+  AuthenticatedVKey_Public -> public
+  AuthenticatedVKey_Private -> private
+
+-- | Very frequently the private part of a total view container is
+-- a map from authentication identities to private views. This
+-- handler bakes this assumption in.
+handleAuthenticatedQuery
+  :: (Monad m, Ord token, View public, View private)
+  => (token -> m (Maybe user))
+  -> (public Proxy -> m (public Identity))
+  -> (private Proxy -> m (private Identity))
+  -> AuthenticatedV public (AuthMapV token private) Proxy
+  -> m (AuthenticatedV public (AuthMapV token private) Identity)
+handleAuthenticatedQuery readToken public private =
+  handleAuthenticatedQuery' public (handleAuthMapQuery readToken private)
+
+-- | Ignore the public part of a total view container.
+privateQueryMorphism
+  :: ( EmptyView private, QueryResult (private (Const SelectedCount)) ~ private Identity
+     )
+  => QueryMorphism
+       (private (Const SelectedCount))
+       (AuthenticatedV public private (Const SelectedCount))
+privateQueryMorphism = QueryMorphism
+  { _queryMorphism_mapQuery = AuthenticatedV . singletonV AuthenticatedVKey_Private
+  , _queryMorphism_mapQueryResult = maybe emptyV id . lookupV AuthenticatedVKey_Private . unAuthenticatedV
+  }
+
+-- | Ignore the private part of a total view container.
+publicQueryMorphism
+  :: ( EmptyView public, QueryResult (public (Const SelectedCount)) ~ public Identity
+     )
+  => QueryMorphism
+       (public (Const SelectedCount))
+       (AuthenticatedV public private (Const SelectedCount))
+publicQueryMorphism = QueryMorphism
+  { _queryMorphism_mapQuery = AuthenticatedV . singletonV AuthenticatedVKey_Public
+  , _queryMorphism_mapQueryResult = maybe emptyV id . lookupV AuthenticatedVKey_Public . unAuthenticatedV
+  }

--- a/common/Rhyolite/Vessel/ErrorV.hs
+++ b/common/Rhyolite/Vessel/ErrorV.hs
@@ -1,0 +1,6 @@
+module Rhyolite.Vessel.ErrorV
+  ( module X
+  ) where
+
+import Rhyolite.Vessel.ErrorV.Internal as X (ErrorV)
+import Rhyolite.Vessel.ErrorV.Internal as X hiding (ErrorV(..))

--- a/common/Rhyolite/Vessel/ErrorV/Internal.hs
+++ b/common/Rhyolite/Vessel/ErrorV/Internal.hs
@@ -1,0 +1,173 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+module Rhyolite.Vessel.ErrorV.Internal where
+
+import Data.Aeson
+import Data.Aeson.GADT.TH
+import Data.Constraint
+import Data.Constraint.Extras
+import Data.GADT.Compare
+import Data.Patch
+import Data.Semigroup
+import Data.Type.Equality
+import Data.Vessel
+import Data.Vessel.Single
+import Data.Vessel.Vessel
+import GHC.Generics
+import Reflex.Query.Class
+
+import Rhyolite.App
+
+-- | An internal type which specifies the two pieces of an 'ErrorV' container.
+-- When constructing a query, only the View piece is present. When constructing
+-- a result, either the Error or View part will be present but never both.
+data ErrorVK err view (v :: (* -> *) -> *) where
+  ErrorVK_Error :: ErrorVK err view (SingleV err)
+  ErrorVK_View :: ErrorVK err view view
+
+deriveJSONGADT ''ErrorVK
+
+instance GEq (ErrorVK err view) where
+  geq = \case
+    ErrorVK_Error -> \case
+      ErrorVK_Error -> Just Refl
+      ErrorVK_View -> Nothing
+    ErrorVK_View -> \case
+      ErrorVK_Error -> Nothing
+      ErrorVK_View -> Just Refl
+
+instance GCompare (ErrorVK err view) where
+  gcompare = \case
+    ErrorVK_Error -> \case
+      ErrorVK_Error -> GEQ
+      ErrorVK_View -> GLT
+    ErrorVK_View -> \case
+      ErrorVK_Error -> GGT
+      ErrorVK_View -> GEQ
+
+instance ArgDict c (ErrorVK err view) where
+  type ConstraintsFor (ErrorVK err view) c = (c (SingleV err), c view)
+  argDict = \case
+    ErrorVK_Error -> Dict
+    ErrorVK_View -> Dict
+
+-- | A functor-parametric container which as a query will contain a value of the
+-- underlying view type and as a result may contain either an err value or a
+-- view result value.
+newtype ErrorV err view g = ErrorV { unErrorV :: Vessel (ErrorVK err view) g }
+  deriving (Generic, EmptyView)
+
+deriving instance (Eq (g (First (Maybe err))), Eq (view g)) => Eq (ErrorV err view g)
+
+instance View view => View (ErrorV err view)
+
+instance (ToJSON (g (First (Maybe err))), ToJSON (view g)) => ToJSON (ErrorV err view g)
+instance (View view, FromJSON (g (First (Maybe err))), FromJSON (view g)) => FromJSON (ErrorV err view g)
+
+deriving instance (Has' Semigroup (ErrorVK err v) (FlipAp g), View v) => Semigroup (ErrorV err v g)
+deriving instance (Has' Semigroup (ErrorVK err v) (FlipAp g), View v) => Monoid (ErrorV err v g)
+deriving instance (Has' Additive (ErrorVK err v) (FlipAp g), View v) => Additive (ErrorV err v g)
+deriving instance (Has' Group (ErrorVK err v) (FlipAp g), View v) => Group (ErrorV err v g)
+deriving instance (PositivePart (g (First (Maybe err))), PositivePart (v g)) => PositivePart (ErrorV err v g)
+
+instance
+  ( Semigroup (v Identity)
+  , View v
+  , QueryResult (v Proxy) ~ v Identity
+  ) => Query (ErrorV err v Proxy) where
+  type QueryResult (ErrorV err v Proxy) = ErrorV err v Identity
+  crop (ErrorV s) (ErrorV r) = ErrorV $ crop s r
+
+instance
+  ( Semigroup (v Identity)
+  , View v
+  , QueryResult (v (Const ())) ~ v Identity
+  ) => Query (ErrorV err v (Const ())) where
+  type QueryResult (ErrorV err v (Const ())) = ErrorV err v Identity
+  crop (ErrorV s) (ErrorV r) = ErrorV $ crop s r
+
+instance
+  ( Semigroup (v Identity)
+  , View v
+  , QueryResult (v (Const SelectedCount)) ~ v Identity
+  ) => Query (ErrorV err v (Const SelectedCount)) where
+  type QueryResult (ErrorV err v (Const SelectedCount)) = ErrorV err v Identity
+  crop (ErrorV s) (ErrorV r) = ErrorV $ crop s r
+
+instance
+  ( View v
+  , Has' Semigroup (ErrorVK err v) (FlipAp (Compose c (VesselLeafWrapper (QueryResult (Vessel (ErrorVK err v) g)))))
+  , Query (Vessel (ErrorVK err v) g)
+  ) => Query (ErrorV err v (Compose c g)) where
+  type QueryResult (ErrorV err v (Compose c g)) = ErrorV err v (Compose c (VesselLeafWrapper (QueryResult (Vessel (ErrorVK err v) g))))
+  crop (ErrorV s) (ErrorV r) = ErrorV $ crop s r
+
+-- | The error part of the view will never be present
+liftErrorV :: View v => v g -> ErrorV e v g
+liftErrorV = ErrorV . singletonV ErrorVK_View
+
+-- | The successful part of the view will never be present
+failureErrorV :: e -> ErrorV e v Identity
+failureErrorV = ErrorV . singletonV ErrorVK_Error . SingleV . Identity . First . Just
+
+-- | Given an 'ErrorV' query and a way to provide a possibly failing result,
+-- construct an ErrorV result.
+buildErrorV
+  :: (View v, Monad m)
+  => (v Proxy -> m (Either e (v Identity)))
+  -> ErrorV e v Proxy
+  -> m (ErrorV e v Identity)
+buildErrorV f (ErrorV v) = case lookupV ErrorVK_View v of
+  Nothing -> pure (ErrorV emptyV)
+  Just v' -> f v' >>= \case
+    Left err -> pure $ failureErrorV err
+    Right val -> pure $ liftErrorV val
+
+-- | Given an 'ErrorV' result, observe whether it is an error result
+-- or a result of the underlying view type.
+observeErrorV
+  :: EmptyView v
+  => ErrorV e v Identity
+  -> Either e (v Identity)
+observeErrorV (ErrorV v) = case lookupV ErrorVK_Error v of
+  Nothing -> Right $ case lookupV ErrorVK_View v of
+    Nothing -> emptyV
+    Just v' -> v'
+  Just err -> case lookupSingleV err of
+    Nothing -> Right emptyV
+    Just e -> Left e
+
+-- | A morphism that only cares about error results.
+unsafeProjectE
+  :: ( EmptyView v
+     )
+  => QueryMorphism
+       ()
+       (ErrorV () v (Const SelectedCount))
+unsafeProjectE = QueryMorphism
+  { _queryMorphism_mapQuery = const (liftErrorV emptyV)
+  , _queryMorphism_mapQueryResult = const ()
+  }
+
+-- | A morphism that only cares about successful results.
+unsafeProjectV
+  :: (EmptyView v, QueryResult (v (Const SelectedCount)) ~ v Identity)
+  => QueryMorphism
+       (v (Const SelectedCount))
+       (ErrorV () v (Const SelectedCount))
+unsafeProjectV = QueryMorphism
+  { _queryMorphism_mapQuery = liftErrorV
+  , _queryMorphism_mapQueryResult = \r -> case observeErrorV r of
+      Left _ -> emptyV
+      Right r' -> r'
+  }
+

--- a/common/rhyolite-common.cabal
+++ b/common/rhyolite-common.cabal
@@ -38,6 +38,7 @@ library
     , dependent-map
     , dependent-monoidal-map
     , dependent-sum
+    , dependent-sum-template
     , file-embed
     , filepath
     , http-types
@@ -48,6 +49,7 @@ library
     , mtl
     , network-uri
     , obelisk-route
+    , patch
     , reflex
     , resource-pool
     , semialign
@@ -81,6 +83,10 @@ library
     Rhyolite.Schema.Task
     Rhyolite.Sign
     Rhyolite.TH
+    Rhyolite.Vessel.ErrorV
+    Rhyolite.Vessel.ErrorV.Internal
+    Rhyolite.Vessel.AuthMapV
+    Rhyolite.Vessel.AuthenticatedV
     Rhyolite.WebSocket
 
   reexported-modules:

--- a/dep/vessel/github.json
+++ b/dep/vessel/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "obsidiansystems",
   "repo": "vessel",
-  "branch": "release/0.1.0.0",
+  "branch": "develop",
   "private": false,
-  "rev": "737e11d223041608ce0ce8dcc482313f8eff094d",
-  "sha256": "0lqb7bx345lrggay3xvsmndhqpmzzrgqzcy0p0b05swiwcfsxnnm"
+  "rev": "cc6e18c10715e4757196cda4c23665472fd15f01",
+  "sha256": "1f0s9zhqxc6iiz8f3fhvd676339bhm3smkq658b7x4qjs9r7wk03"
 }


### PR DESCRIPTION
These data structures are based on previous solutions for authentication by @danbornside based on SubVessel (wrapped as AuthMapV) as well as Cale's idea for ErrorV which handles possibly failing queries in a way that does not expose incoherent behavior to the end-users. There is also an AuthenticatedV wrapper which glues together two view selectors which need have no relation to each other in particular, but the intended use case is to combine it with AuthMapV.

The handler provided for AuthMapV assumes that the result of the query does not depend on the specific identity making the query. This allows efficient aggregation of queries across different authenticated users. There are other sorts of authenticated queries which do depend on the specific identity, like querying for one's own profile. One way we can accommodate such queries is to extend AuthenticatedV with a third key for "Personal" queries which use AuthMapV but do not do query aggregation.

This PR should be updated once https://github.com/obsidiansystems/vessel/pull/14 is merged.