### PR TITLE
Added beam versions of taskWorker and Task

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 This project's release branch is `master`. This log is written from the perspective of the release branch: when changes hit `master`, they are considered released, and the date should reflect that release.
 
 ## Unreleased
+* Added Beam versions of `Rhyolite.Task.Groundhog.Worker.taskWorker` and `Rhyolite.Task.Groundhog.Task`, in `Rhyolite.Task.Groundhog.Worker` and `Rhyolite.Task.Beam` respectively.
 * Removed `Rhyolite.Request.Common`, now using functions from Aeson directly. Use `decode'` instead of `decodeValue'`.
 
 * Breaking changes:

--- a/beam/LICENSE
+++ b/beam/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2021, Obsidian Systems LLC
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Obsidian Systems LLC nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/beam/README.md
+++ b/beam/README.md
@@ -1,0 +1,3 @@
+# rhyolite-beam
+
+Beam based task workers.

--- a/beam/rhyolite-beam-task-worker.cabal
+++ b/beam/rhyolite-beam-task-worker.cabal
@@ -21,6 +21,7 @@ library
   build-depends:
       async
     , base
+    , beam-automigrate
     , beam-core
     , beam-postgres
     , containers
@@ -56,6 +57,7 @@ test-suite test
   default-language: Haskell2010
   build-depends:
       base
+    , beam-automigrate
     , beam-core
     , beam-postgres
     , containers

--- a/beam/rhyolite-beam-task-worker.cabal
+++ b/beam/rhyolite-beam-task-worker.cabal
@@ -24,6 +24,7 @@ library
     , beam-core
     , beam-postgres
     , containers
+    , filepath
     , gargoyle-postgresql-connect
     , hspec
     , lens
@@ -38,6 +39,7 @@ library
     , text
     , time
     , unbounded-delays
+    , unix
 
   hs-source-dirs:   src
   default-language: Haskell2010
@@ -57,6 +59,7 @@ test-suite test
     , beam-core
     , beam-postgres
     , containers
+    , filepath
     , gargoyle-postgresql-connect
     , hspec
     , lens
@@ -66,4 +69,5 @@ test-suite test
     , resource-pool
     , rhyolite-beam-task-worker
     , text
+    , unix
   ghc-options:    -threaded

--- a/beam/rhyolite-beam-task-worker.cabal
+++ b/beam/rhyolite-beam-task-worker.cabal
@@ -1,5 +1,5 @@
 cabal-version:      2.4
-name:               rhyolite-beam
+name:               rhyolite-beam-task-worker
 version:            0.1.0.0
 synopsis:           Beam based task workers.
 homepage:           https://github.com/obsidiansystems/rhyolite
@@ -38,3 +38,20 @@ library
   hs-source-dirs:   src
   default-language: Haskell2010
   ghc-options:      -Wall
+
+test-suite test
+  type:           exitcode-stdio-1.0
+  main-is:        Test.hs
+  hs-source-dirs: test
+  build-depends:
+      base
+    , beam-core
+    , beam-postgres
+    , hspec
+    , lens
+    , monad-logger
+    , postgresql-simple
+    , psql-serializable
+    , rhyolite-beam-task-worker
+    , text
+    , transformers

--- a/beam/rhyolite-beam-task-worker.cabal
+++ b/beam/rhyolite-beam-task-worker.cabal
@@ -23,6 +23,9 @@ library
     , base
     , beam-core
     , beam-postgres
+    , containers
+    , gargoyle-postgresql-connect
+    , hspec
     , lens
     , lifted-base
     , monad-logger
@@ -31,6 +34,7 @@ library
     , mtl
     , postgresql-simple
     , psql-serializable
+    , resource-pool
     , text
     , time
     , unbounded-delays
@@ -40,14 +44,19 @@ library
   ghc-options:      -Wall
 
 test-suite test
+  other-modules:
+      Types
+    , Utils
+
   type:           exitcode-stdio-1.0
   main-is:        Test.hs
   hs-source-dirs: test
+  default-language: Haskell2010
   build-depends:
-    -- Base version 4.7 required to make readMVar multiple blocking
-      base >= 4.7
+      base
     , beam-core
     , beam-postgres
+    , containers
     , gargoyle-postgresql-connect
     , hspec
     , lens
@@ -57,5 +66,4 @@ test-suite test
     , resource-pool
     , rhyolite-beam-task-worker
     , text
-    , transformers
   ghc-options:    -threaded

--- a/beam/rhyolite-beam-task-worker.cabal
+++ b/beam/rhyolite-beam-task-worker.cabal
@@ -44,14 +44,18 @@ test-suite test
   main-is:        Test.hs
   hs-source-dirs: test
   build-depends:
-      base
+    -- Base version 4.7 required to make readMVar multiple blocking
+      base >= 4.7
     , beam-core
     , beam-postgres
+    , gargoyle-postgresql-connect
     , hspec
     , lens
     , monad-logger
     , postgresql-simple
     , psql-serializable
+    , resource-pool
     , rhyolite-beam-task-worker
     , text
     , transformers
+  ghc-options:    -threaded

--- a/beam/rhyolite-beam.cabal
+++ b/beam/rhyolite-beam.cabal
@@ -1,0 +1,39 @@
+cabal-version:      2.4
+name:               rhyolite-beam
+version:            0.1.0.0
+synopsis:           Beam based task workers.
+homepage:           https://github.com/obsidiansystems/rhyolite
+bug-reports:        https://github.com/obsidiansystems/rhyolite/issues
+license:            BSD-3-Clause
+license-file:       LICENSE
+author:             Obsidian Systems LLC
+maintainer:         maintainer@obsidian.systems
+copyright:          2021 Obsidian Systems LLC
+category:           Web
+extra-source-files: README.md
+
+library
+  exposed-modules:
+    Rhyolite.DB.Beam
+    Rhyolite.Task.Beam
+    Rhyolite.Task.Beam.Worker
+
+  build-depends:
+      async
+    , base
+    , beam-core
+    , beam-postgres
+    , lifted-base
+    , monad-logger
+    , monad-logger-extras
+    , monad-control
+    , mtl
+    , postgresql-simple
+    , psql-serializable
+    , text
+    , time
+    , unbounded-delays
+
+  hs-source-dirs:   src
+  default-language: Haskell2010
+  ghc-options:      -Wall

--- a/beam/rhyolite-beam.cabal
+++ b/beam/rhyolite-beam.cabal
@@ -23,6 +23,7 @@ library
     , base
     , beam-core
     , beam-postgres
+    , lens
     , lifted-base
     , monad-logger
     , monad-logger-extras

--- a/beam/src/Rhyolite/DB/Beam.hs
+++ b/beam/src/Rhyolite/DB/Beam.hs
@@ -1,6 +1,8 @@
 {-# Language FlexibleContexts #-}
 {-# Language TypeFamilies #-}
--- | Utility functions for using Beam with Postgres
+{-|
+Description : Utility functions for using Beam with Postgres Transactions.
+-}
 module Rhyolite.DB.Beam where
 
 import Database.Beam

--- a/beam/src/Rhyolite/DB/Beam.hs
+++ b/beam/src/Rhyolite/DB/Beam.hs
@@ -1,0 +1,13 @@
+{-# Language FlexibleContexts #-}
+{-# Language TypeFamilies #-}
+-- | Utility functions for using Beam with Postgres
+module Rhyolite.DB.Beam where
+
+import Database.Beam
+import Database.Beam.Postgres
+
+import Database.PostgreSQL.Simple.Transaction
+
+-- | Run beam SQL statements inside a Postgres Serializable Transaction
+withTransactionSerializableRunBeamPostgres :: (MonadIO m) => Connection -> Pg a -> m a
+withTransactionSerializableRunBeamPostgres dbConn = liftIO . withTransactionSerializable dbConn . runBeamPostgres dbConn

--- a/beam/src/Rhyolite/Task/Beam.hs
+++ b/beam/src/Rhyolite/Task/Beam.hs
@@ -1,8 +1,13 @@
 {-# Language FunctionalDependencies #-}
 {-# Language KindSignatures #-}
+{-# Language TemplateHaskell #-}
+{-# Language FlexibleInstances #-}
+{-# Language DeriveAnyClass #-}
+{-# Language DeriveGeneric #-}
 -- | Contains definitions for tasks, and tables that have tasks.
 module Rhyolite.Task.Beam where
 
+import Control.Lens.TH
 import Data.Text (Text)
 
 import Database.Beam
@@ -10,11 +15,16 @@ import Database.Beam
 -- | Data Family for tables that have tasks embedded in them.
 -- Specifically, this means tables that have the following 2 fields (columns)
 -- 1. A result field, containg an optional value
--- 2. A checkout out by field, containg the name of the worker that checked out this task
+-- 2. A checked out by field, containing the name of the worker that checked out this task
 -- For unclaimed tasks, both these fields are null (Nothing).
 -- When a task is checked out by a worker, the checkout out field is set to the worker's name. Result is still null.
 -- When a task is completed, the result field is filled with the result, and the checked out field is set to null.
 -- The type of result is dependent upon the task, hence the functional dependency between the table and the result type.
-class HasTasks (table :: (* -> *) -> *) a | table -> a where
-  _task_result :: table f -> C f (Maybe a)
-  _task_checkedOutBy :: table f -> C f (Maybe Text)
+data Task i o f = Task
+  { _taskPayload :: C f i
+  , _taskResult :: C f (Maybe o)
+  , _taskCheckedOutBy :: C f (Maybe Text)
+  } deriving (Generic, Beamable)
+
+
+$(makeClassy ''Task)

--- a/beam/src/Rhyolite/Task/Beam.hs
+++ b/beam/src/Rhyolite/Task/Beam.hs
@@ -5,7 +5,14 @@
 {-# Language KindSignatures #-}
 {-# Language RankNTypes #-}
 {-# Language TemplateHaskell #-}
--- | Contains definitions for tasks, and tables that have tasks.
+{-|
+Description : Contains definitions for tasks, and tables that have tasks.
+
+For more details on how a Task is defined, refer to the Task data type below.
+
+This module should be used when there is a list of tasks to be processed, and a limited number of workers available
+to process those tasks. The workers will pick off tasks one by one, and store the results back in the table of tasks.
+-}
 module Rhyolite.Task.Beam where
 
 import Control.Lens.TH
@@ -13,19 +20,19 @@ import Data.Text (Text)
 
 import Database.Beam
 
--- TODO Update the documentation here
--- | Data Family for tables that have tasks embedded in them.
--- Specifically, this means tables that have the following 2 fields (columns)
--- 1. A result field, containg an optional value
--- 2. A checked out by field, containing the name of the worker that checked out this task
--- For unclaimed tasks, both these fields are null (Nothing).
+-- | Data type for tables that have tasks embedded in them.
+-- Specifically, this means tables that have the following 3 fields (columns)
+-- 1. A task payload, which will be used an an input to the task worker.
+-- 2. A result field, containg an optional value.
+-- 3. A checked out by field, containing the name of the worker that checked out this task.
+-- For unclaimed tasks, both fields 2 and 3 are null (Nothing).
 -- When a task is checked out by a worker, the checkout out field is set to the worker's name. Result is still null.
 -- When a task is completed, the result field is filled with the result, and the checked out field is set to null.
 -- The type of result is dependent upon the task, hence the functional dependency between the table and the result type.
 data Task i o f = Task
-  { _taskPayload :: C f i
-  , _taskResult :: C f (Maybe o)
-  , _taskCheckedOutBy :: C f (Maybe Text)
+  { _taskPayload :: C f i -- ^ Used as an input to the worker to which this task will be assigned.
+  , _taskResult :: C f (Maybe o) -- ^ Will contain the output of the task worker, once it is available. Till then, it will be Nothing.
+  , _taskCheckedOutBy :: C f (Maybe Text) -- ^ Will contain the task worker name. It is equal to Nothing till it gets assigned.
   } deriving (Generic, Beamable)
 
 makeLenses ''Task

--- a/beam/src/Rhyolite/Task/Beam.hs
+++ b/beam/src/Rhyolite/Task/Beam.hs
@@ -17,7 +17,6 @@ to process those tasks. The workers will pick off tasks one by one, and store th
 module Rhyolite.Task.Beam where
 
 import Control.Lens.TH
-import Data.Text (Text)
 
 import Database.Beam
 
@@ -25,17 +24,17 @@ import Database.Beam
 -- Specifically, this means tables that have the following 3 fields (columns)
 -- 1. A task payload, which will be used an an input to the task worker.
 -- 2. A result field, containg an optional value.
--- 3. A checked out by field, containing the name of the worker that checked out this task.
+-- 3. A checked out by field, containing an id of the worker that checked out this task.
 -- For unclaimed tasks, both fields 2 and 3 are null (Nothing).
--- When a task is checked out by a worker, the checkout out field is set to the worker's name. Result is still null.
+-- When a task is checked out by a worker, the checkout out field is set to the worker's id. Result is still null.
 -- When a task is completed, the result field is filled with the result, and the checked out field is set to null.
 -- The type of result is dependent upon the task, hence the functional dependency between the table and the result type.
-data Task i o f = Task
+data Task i o t f = Task
   { _taskPayload :: C f i -- ^ Used as an input to the worker to which this task will be assigned.
   , _taskResult :: C f (Maybe o) -- ^ Will contain the output of the task worker, once it is available. Till then, it will be Nothing.
-  , _taskCheckedOutBy :: C f (Maybe Text) -- ^ Will contain the task worker name. It is equal to Nothing till it gets assigned.
+  , _taskCheckedOutBy :: C f (Maybe t) -- ^ Will contain the task worker id. It is equal to Nothing till it gets assigned.
   } deriving (Generic, Beamable)
 
-deriving instance (Eq i, Eq o) => Eq (Task i o Identity)
+deriving instance (Eq i, Eq o, Eq t) => Eq (Task i o t Identity)
 
 makeLenses ''Task

--- a/beam/src/Rhyolite/Task/Beam.hs
+++ b/beam/src/Rhyolite/Task/Beam.hs
@@ -1,17 +1,20 @@
-{-# Language FunctionalDependencies #-}
-{-# Language KindSignatures #-}
-{-# Language TemplateHaskell #-}
-{-# Language FlexibleInstances #-}
 {-# Language DeriveAnyClass #-}
 {-# Language DeriveGeneric #-}
+{-# Language FlexibleInstances #-}
+{-# Language FunctionalDependencies #-}
+{-# Language KindSignatures #-}
+{-# Language RankNTypes #-}
+{-# Language TemplateHaskell #-}
 -- | Contains definitions for tasks, and tables that have tasks.
 module Rhyolite.Task.Beam where
 
 import Control.Lens.TH
+import Control.Lens.Type
 import Data.Text (Text)
 
 import Database.Beam
 
+-- TODO Update the documentation here
 -- | Data Family for tables that have tasks embedded in them.
 -- Specifically, this means tables that have the following 2 fields (columns)
 -- 1. A result field, containg an optional value
@@ -26,5 +29,20 @@ data Task i o f = Task
   , _taskCheckedOutBy :: C f (Maybe Text)
   } deriving (Generic, Beamable)
 
+makeLensesWith (lensRulesFor
+  [ ("_taskPayload", "taskPayload'")
+  , ("_taskResult", "taskResult'")
+  , ("_taskCheckedOutBy", "taskCheckoutBy'")
+  ]) ''Task
 
-$(makeClassy ''Task)
+class HasTask t i o | t -> i o where
+  task :: forall f. Lens' (t f) (Task i o f)
+  taskCheckedOutBy :: forall f. Lens' (t f) (C f (Maybe Text))
+  taskCheckedOutBy = task . taskCheckoutBy'
+  taskPayload :: forall f. Lens' (t f) (C f i)
+  taskPayload = task . taskPayload'
+  taskResult :: forall f. Lens' (t f) (C f (Maybe o))
+  taskResult = task . taskResult'
+
+instance HasTask (Task i o) i o where
+  task = id

--- a/beam/src/Rhyolite/Task/Beam.hs
+++ b/beam/src/Rhyolite/Task/Beam.hs
@@ -9,7 +9,6 @@
 module Rhyolite.Task.Beam where
 
 import Control.Lens.TH
-import Control.Lens.Type
 import Data.Text (Text)
 
 import Database.Beam
@@ -29,20 +28,4 @@ data Task i o f = Task
   , _taskCheckedOutBy :: C f (Maybe Text)
   } deriving (Generic, Beamable)
 
-makeLensesWith (lensRulesFor
-  [ ("_taskPayload", "taskPayload'")
-  , ("_taskResult", "taskResult'")
-  , ("_taskCheckedOutBy", "taskCheckoutBy'")
-  ]) ''Task
-
-class HasTask t i o | t -> i o where
-  task :: forall f. Lens' (t f) (Task i o f)
-  taskCheckedOutBy :: forall f. Lens' (t f) (C f (Maybe Text))
-  taskCheckedOutBy = task . taskCheckoutBy'
-  taskPayload :: forall f. Lens' (t f) (C f i)
-  taskPayload = task . taskPayload'
-  taskResult :: forall f. Lens' (t f) (C f (Maybe o))
-  taskResult = task . taskResult'
-
-instance HasTask (Task i o) i o where
-  task = id
+makeLenses ''Task

--- a/beam/src/Rhyolite/Task/Beam.hs
+++ b/beam/src/Rhyolite/Task/Beam.hs
@@ -1,0 +1,20 @@
+{-# Language FunctionalDependencies #-}
+{-# Language KindSignatures #-}
+-- | Contains definitions for tasks, and tables that have tasks.
+module Rhyolite.Task.Beam where
+
+import Data.Text (Text)
+
+import Database.Beam
+
+-- | Data Family for tables that have tasks embedded in them.
+-- Specifically, this means tables that have the following 2 fields (columns)
+-- 1. A result field, containg an optional value
+-- 2. A checkout out by field, containg the name of the worker that checked out this task
+-- For unclaimed tasks, both these fields are null (Nothing).
+-- When a task is checked out by a worker, the checkout out field is set to the worker's name. Result is still null.
+-- When a task is completed, the result field is filled with the result, and the checked out field is set to null.
+-- The type of result is dependent upon the task, hence the functional dependency between the table and the result type.
+class HasTasks (table :: (* -> *) -> *) a | table -> a where
+  _task_result :: table f -> C f (Maybe a)
+  _task_checkedOutBy :: table f -> C f (Maybe Text)

--- a/beam/src/Rhyolite/Task/Beam.hs
+++ b/beam/src/Rhyolite/Task/Beam.hs
@@ -4,6 +4,7 @@
 {-# Language FunctionalDependencies #-}
 {-# Language KindSignatures #-}
 {-# Language RankNTypes #-}
+{-# Language StandaloneDeriving #-}
 {-# Language TemplateHaskell #-}
 {-|
 Description : Contains definitions for tasks, and tables that have tasks.
@@ -34,5 +35,7 @@ data Task i o f = Task
   , _taskResult :: C f (Maybe o) -- ^ Will contain the output of the task worker, once it is available. Till then, it will be Nothing.
   , _taskCheckedOutBy :: C f (Maybe Text) -- ^ Will contain the task worker name. It is equal to Nothing till it gets assigned.
   } deriving (Generic, Beamable)
+
+deriving instance (Eq i, Eq o) => Eq (Task i o Identity)
 
 makeLenses ''Task

--- a/beam/src/Rhyolite/Task/Beam/Worker.hs
+++ b/beam/src/Rhyolite/Task/Beam/Worker.hs
@@ -1,0 +1,147 @@
+{-# Language FlexibleContexts #-}
+{-# Language TypeFamilies #-}
+{-# Language RankNTypes #-}
+-- | Utility functions for creating worker threads, and Beam specific task workers for running SQL.
+module Rhyolite.Task.Beam.Worker where
+
+import Control.Concurrent
+import Control.Concurrent.Async
+import Control.Concurrent.Thread.Delay
+import Control.Exception.Lifted (bracket)
+import Control.Monad (forM)
+import Control.Monad.Cont
+import Control.Monad.Logger (askLoggerIO, MonadLoggerIO)
+import Control.Monad.Logger.Extras (Logger(..))
+import Control.Monad.Trans.Control
+import Data.Time
+import Data.Text (Text)
+
+import Database.Beam
+import Database.Beam.Backend.SQL
+import Database.Beam.Postgres
+import Database.Beam.Postgres.Full
+import Database.Beam.Postgres.Syntax
+import Database.Beam.Query.Internal (QNested)
+import Database.Beam.Schema.Tables
+
+import Database.PostgreSQL.Serializable
+import Rhyolite.DB.Beam
+import Rhyolite.Task.Beam
+
+-- | This function retrieves the first unclaimed task from the table (passed as an argument).
+-- It then assigns this task to itself, and runs the action passed to it.
+-- Once it has the output of that action, it sets the output as the result of the task,
+-- thereby marking it as completed.
+taskWorker ::
+  ( MonadIO m, MonadLoggerIO m, Database be db
+  , Beamable table, Table table, HasTasks table b
+  , FromBackendRow be (PrimaryKey table Identity)
+  , FieldsFulfillConstraint (HasSqlEqualityCheck be) (PrimaryKey table)
+  , FieldsFulfillConstraint (HasSqlValueSyntax PgValueSyntax) (PrimaryKey table)
+  , FromBackendRow be a, HasSqlValueSyntax PgValueSyntax b
+  , be ~ Postgres, f ~ QExpr be (QNested (QNested QBaseScope)))
+  => Connection -- ^ Connection to the database
+  -> DatabaseEntity be db (TableEntity table) -- ^ A table containing embedded tasks.
+  -> f Bool -- ^ A filter for selecting tasks from the table.
+  -> (table f -> C f a) -- ^ Retrieve a custom field from the table, to be passed as an argument to the action.
+  -> (a -> Serializable (m (Serializable b))) -- ^ The action, whose output is set as the result of the task.
+  -> Text -- ^ Name of the worker
+  -> m Bool
+taskWorker dbConn table ready inputField go workerName = do
+  logger <- askLoggerIO
+  checkedOutValue <-
+    -- BEGIN Transaction
+
+    -- Do the following inside a transaction:
+    -- 1. Get the first task that is not currently checked out by any worker, lock this task
+    -- 2. Update this task to reflect that it has been checked out by current worker
+    -- 3. Perform the serializable task
+    withTransactionSerializableRunBeamPostgres dbConn $ do
+      primaryKeyAndInput <- runSelectReturningOne $ select $
+        -- Only lock one row (limit_ 1)
+        lockingAllTablesFor_ PgSelectLockingStrengthUpdate Nothing $ limit_ 1 $ do
+          task <- all_ table
+
+          -- Both task fields should be empty for an unclaimed task
+          -- Also apply any other filters that may have been passed, using ready
+          guard_ $ isNothing_ (_task_result task) &&. isNothing_ (_task_checkedOutBy task) &&. ready
+
+          -- Return the primary key (task id) along with a custom field that the user asked for.
+          pure (primaryKey task, inputField task)
+
+      -- In case we did not find any rows, no update SQL will be run
+      -- The row lock that we acquired above will be reset when the transaction ends.
+      forM primaryKeyAndInput $ \(taskId, input) -> do
+        -- Mark the retrieved task as checked out, by the current worker
+        runUpdate $
+          update table
+            (\task -> _task_checkedOutBy task <-. val_ (Just workerName))
+            (\task -> primaryKey task ==. val_ taskId)
+
+        runSerializableInsideTransaction dbConn (Logger logger) $ (,) taskId <$> go input
+    -- END Transaction, release row lock
+
+  case checkedOutValue of
+    Nothing -> pure False
+    Just (taskId, action) -> do
+      -- Get the followup Serializable
+      followup <- action
+
+      -- BEGIN Transaction
+      withTransactionSerializableRunBeamPostgres dbConn $ do
+        -- Get the result value from the serializable
+        b <- runSerializableInsideTransaction dbConn (Logger logger) followup
+
+        -- Update the task's result field, set checked out field to null
+        runUpdate $ update table
+          (\task -> mconcat
+                    [ _task_result task <-. val_ (Just b)
+                    , _task_checkedOutBy task <-. val_ Nothing])
+          (\task -> primaryKey task ==. val_ taskId)
+      -- END Transaction
+
+      pure True
+
+-- | Run a worker thread
+-- The worker will wake up whenever the timer expires or the wakeup action is called
+-- Once woken up, the worker will be run repeatedly until it reports that it was not able to find any work to do; then it will start sleeping for the given duration.
+-- If the wakeup action is called while the worker is running, the worker will run again as soon as it finishes, even if it returns False.  This is necessary because otherwise, since checking for work isn't generally atomic, there would be a race condition: worker starts (e.g. enters looking-for-work transaction), work is created, wakeup called, worker finishes with no work found, sleep.
+withWorker :: (MonadIO m, MonadBaseControl IO m) => NominalDiffTime -> IO Bool -> (IO () -> m a) -> m a
+withWorker d work child = do
+  initialStartVar <- liftIO $ newMVar ()
+  startVarVar <- liftIO $ newMVar initialStartVar
+  let wakeup = void $ withMVar startVarVar $ \startVar -> tryPutMVar startVar ()
+      sleep startVar = void $ forkIO $ do
+        delay $ ceiling $ d * 1000000
+        putMVar startVar () -- Do this blockingly so the thread can theoretically be GCed if it becomes useless
+      go startVar = do
+        nextStartVar <- newEmptyMVar
+        void $ takeMVar startVar
+        modifyMVar_ startVarVar $ \_ -> pure nextStartVar
+        didWork <- withAsync work waitCatch
+        case didWork of
+          Left e -> do
+            putStrLn $ "withWorker: error in worker: " <> show e --TODO: Use MonadLogger
+            sleep nextStartVar
+          Right True -> void $ tryPutMVar nextStartVar ()
+          Right False -> sleep nextStartVar
+        go nextStartVar
+  bracket (liftIO $ async $ go initialStartVar) (liftIO . cancel) $ \_ -> child wakeup
+
+-- | Run multiple workers in parallel on the same task
+withConcurrentWorkers
+  :: forall r a. Int
+  -> NominalDiffTime
+  -> (a -> IO Bool)
+  -> (Int -> a)
+  -> (IO () -> IO r)
+  -> IO r
+withConcurrentWorkers n0 d work argFn = runContT $ go n0
+  where
+    go :: Int -> ContT r IO (IO ())
+    go n = do
+      wakeup <- ContT $ withWorker d (work $ argFn n)
+      wakeupRest <- if n > 1
+        then go (n-1)
+        else return $ return ()
+      return (wakeup *> wakeupRest)

--- a/beam/test/Test.hs
+++ b/beam/test/Test.hs
@@ -1,24 +1,31 @@
 {-# Language DeriveAnyClass #-}
 {-# Language DeriveGeneric #-}
+{-# Language FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# Language StandaloneDeriving #-}
 {-# Language TemplateHaskell #-}
 {-# Language TypeFamilies #-}
 
 module Main where
 
-import Control.Exception (bracket)
+import Control.Concurrent (forkIO, threadDelay)
+import Control.Concurrent.MVar
+import Control.Exception
 import Control.Lens.TH
+import Control.Monad (void)
 import Control.Monad.Logger
 import Control.Monad.Trans.Reader
 import Data.IORef
 import Data.Int (Int32)
-import Data.Maybe (isJust)
+import Data.List (sort)
+import Data.Pool (withResource)
 import Data.String (fromString)
-import Data.Text
+import Data.Text (Text)
 
 import Database.Beam
 import Database.Beam.Postgres
 import Database.PostgreSQL.Simple
+import Gargoyle.PostgreSQL.Connect
 
 import Test.Hspec
 
@@ -35,6 +42,8 @@ makeLenses ''TestTaskT
 
 type TestTask = TestTaskT Identity
 type TestTaskId = PrimaryKey TestTaskT Identity
+
+deriving instance Eq TestTask
 
 instance Table TestTaskT where
    data PrimaryKey TestTaskT f = TestTaskId (Columnar f Int32) deriving (Generic, Beamable)
@@ -64,8 +73,11 @@ closeDB dbConn = do
   execute dbConn "drop table tasks;" ()
   close dbConn
 
+-- withDB :: (Connection -> IO ()) -> IO ()
+-- withDB = bracket setupDB closeDB
+
 withDB :: (Connection -> IO ()) -> IO ()
-withDB = bracket setupDB closeDB
+withDB f = withDb "db" $ \pool -> withResource pool f
 
 instance MonadLogger IO where
   monadLoggerLog _ _ _ msg = print $ toLogStr msg
@@ -73,11 +85,16 @@ instance MonadLogger IO where
 instance MonadLoggerIO IO where
   askLoggerIO = pure (\_ _ _ logStr -> print logStr)
 
+data TestException = TestException
+   deriving (Show, Typeable)
+
+instance Exception TestException
+
 main :: IO ()
 main = hspec $ around withDB $ do
   describe "taskWorker" $ do
     it "works functionally, bare minimum test" $ \c -> do
-      ioBool <- newIORef False
+      boolRef <- newIORef False
 
       runBeamPostgres c $ runInsert $
         insert (_tasks tasksDb) $
@@ -87,7 +104,7 @@ main = hspec $ around withDB $ do
       -- The worker should not have failed
       taskWorker c (_tasks tasksDb) (val_ True) taskDetails (\_ -> do
         pure $ do
-          atomicModifyIORef ioBool (const (True, ()))
+          atomicModifyIORef boolRef (const (True, ()))
           pure $ pure True
         ) "Test-Worker" `shouldReturn` True
 
@@ -99,7 +116,135 @@ main = hspec $ around withDB $ do
         Nothing -> do
           fail "There should have been 1 row in the tasks table"
           pure ()
-        Just (TestTask (Task _ result _) _) -> result `shouldBe` Just True
+        Just (TestTask (Task _ result checkedOutBy) _) -> do
+          result `shouldBe` Just True
+          checkedOutBy `shouldBe` Nothing
 
       -- The worker should have completed its task
-      readIORef ioBool `shouldReturn` True
+      readIORef boolRef `shouldReturn` True
+    
+    it "fails, keeps row in database" $ \c -> do
+      boolRef <- newIORef False
+
+      runBeamPostgres c $ runInsert $
+        insert (_tasks tasksDb) $
+        insertValues
+          [ TestTask (Task "Toggle an IORef Bool" Nothing Nothing) 1 ]
+
+      -- The worker should not have failed
+      taskWorker c (_tasks tasksDb) (val_ True) taskDetails (\_ -> do
+        pure $ do
+          -- Throw an exception to signal failure
+          throw TestException
+          atomicModifyIORef boolRef (const (True, ()))
+          pure $ pure True
+        ) "Test-Worker" `shouldThrow` anyException
+
+      maybeTask <- runBeamPostgres c $ runSelectReturningOne $
+        select $ all_ (_tasks tasksDb)
+
+      -- The worker should have updated the database with its task result
+      case maybeTask of
+        Nothing -> do
+          fail "There should have been 1 row in the tasks table"
+          pure ()
+        Just (TestTask (Task _ _ checkedOutBy) _) -> checkedOutBy `shouldBe` Just "Test-Worker"
+
+      -- The worker failed its task, so the ioref should still be false
+      readIORef boolRef `shouldReturn` False
+
+    it "works concurrently, 2 workers" $ \c1 -> do
+      -- MVar which will be used to block both the workers once they have retrieved tasks from the table.
+      awakenMVar <- newEmptyMVar :: IO (MVar ())
+
+      -- Will be used inside worker task as an increment action
+      countRef <- newIORef 0
+
+      -- Add two separate tasks to the table
+      runBeamPostgres c1 $ runInsert $
+        insert (_tasks tasksDb) $
+        insertValues
+          [ TestTask (Task "Toggle an IORef Bool" Nothing Nothing) 1
+          , TestTask (Task "Toggle an IORef Bool" Nothing Nothing) 2
+          ]
+
+      -- Spawn two workers in separate threads
+      void $ forkIO $ void $ taskWorker c1 (_tasks tasksDb) (val_ True) taskDetails (\_ -> do
+        pure $ do
+          -- Block on awakenMVar
+          () <- readMVar awakenMVar
+          atomicModifyIORef countRef (\i -> (i+1, ()))
+          pure $ pure True
+        ) "Test-Worker 1"
+
+      c2 <- connect defaultConnectInfo
+
+      void $ forkIO $ void $ taskWorker c2 (_tasks tasksDb) (val_ True) taskDetails (\_ -> do
+        pure $ do
+          -- Block on awakenMVar
+          () <- readMVar awakenMVar
+          atomicModifyIORef countRef (\i -> (i+1, ()))
+          pure $ pure True
+        ) "Test-Worker 2"
+
+      -- Wait for 500ms
+      threadDelay $ 500 * 1000
+
+      -- Both workers should have retrieved tasks from the table and blocked by now
+      tasks <- runBeamPostgres c1 $ runSelectReturningList $
+        select $ all_ (_tasks tasksDb)
+
+      -- Both tasks should have been checkedout
+      sort (map (_taskCheckedOutBy . _taskDetails) tasks) `shouldBe` [Just "Test-Worker 1", Just "Test-Worker 2"]
+
+      -- Unblock both workers
+      putMVar awakenMVar ()
+
+      -- Wait for 500ms
+      threadDelay $ 500 * 1000
+
+      -- Both tasks should have been completed by now, and updated in the table
+      tasks <- runBeamPostgres c1 $ runSelectReturningList $
+        select $ all_ (_tasks tasksDb)
+
+      -- Both tasks should have checked out by set to null
+      map (_taskCheckedOutBy . _taskDetails) tasks `shouldBe` replicate 2 Nothing
+      -- Both tasks' result should be Just True
+      map (_taskResult . _taskDetails) tasks `shouldBe` replicate 2 (Just True)
+
+      -- The increment task should also have been completed
+      readIORef countRef `shouldReturn` 2
+
+    it "never picks up a checked out or completed task" $ \c -> do
+      -- Will be used later in the worker's task
+      boolRef <- newIORef False
+
+      let
+        tasks =
+          [ TestTask (Task "Toggle an IORef Bool" (Just True) Nothing) 1 -- Completed Task
+          , TestTask (Task "Toggle an IORef Bool" Nothing (Just "Test-Worker 1")) 2 -- Task already checked out
+          ]
+
+      -- Add two separate tasks to the table
+      runBeamPostgres c $ runInsert $
+        insert (_tasks tasksDb) $
+        insertValues tasks
+
+      -- Spawn a worker in a separate threads
+      void $ forkIO $ void $ taskWorker c (_tasks tasksDb) (val_ True) taskDetails (\_ -> do
+        pure $ do
+          atomicModifyIORef boolRef (const (True, ()))
+          pure $ pure True
+        ) "Test-Worker 2"
+
+      -- Wait for 3 whole seconds
+      threadDelay $ 3 * 1000 * 1000
+
+      -- Our IORef should still contain False
+      readIORef boolRef `shouldReturn` False
+
+      -- Both the tasks should not have been modified
+      tasksInDb <- runBeamPostgres c $ runSelectReturningList $
+        select $ all_ (_tasks tasksDb)
+
+      tasksInDb == tasks `shouldBe` True

--- a/beam/test/Test.hs
+++ b/beam/test/Test.hs
@@ -27,24 +27,23 @@ import Rhyolite.Task.Beam.Worker
 import Types
 import Utils
 
-setupDB :: IO Connection
-setupDB = do
-  dbConn <- connect defaultConnectInfo
+-- TODO : Use beam-automigrate
+-- TODO : Check how we can achieve complete haddock coverage even with lens
+
+setupTable :: Connection -> IO Connection
+setupTable dbConn = do
   execute dbConn "create table tasks (payload integer NOT NULL, result boolean, checked_out_by varchar(30), id integer PRIMARY KEY);" ()
   pure dbConn
 
-closeDB :: Connection -> IO ()
-closeDB dbConn = do
-  execute dbConn "drop table tasks;" ()
-  close dbConn
+deleteTable :: Connection -> IO ()
+deleteTable dbConn = void $ execute dbConn "drop table tasks;" ()
 
--- withDB :: (Connection -> IO ()) -> IO ()
--- withDB = bracket setupDB closeDB
+withTables :: Connection -> IO () -> IO ()
+withTables dbConn = bracket (setupTable dbConn) deleteTable . const
 
-withDB :: (Connection -> IO ()) -> IO ()
-withDB f = do
-  tmp <- mkdtemp "psql-test"
-  withDb (tmp </> "db") $ \pool -> withResource pool f
+withDB :: FilePath -> (Connection -> IO ()) -> IO ()
+withDB dbPath f = do
+  withDb dbPath $ \pool -> withResource pool f
 
 -- Time taken to process one task - 100ms
 timeForOneTask :: Int
@@ -52,195 +51,199 @@ timeForOneTask = 100 * 1000
 
 main :: IO ()
 main = do
-  hspec $ around withDB $ do
-    describe "taskWorker" $ do
-      -- TEST 1
-      --   Creates a task that toggles a boolean. Tests functionally that everything works.
-      it "works functionally, bare minimum test" $ \c -> do
-        -- SETUP
-        -- Create an IORef which will be toggled by the worker
-        -- Add a task to the table
-        let
-          initBool = False
-        boolRef <- newIORef initBool
-        insertTestTasks c [ createTask 1 ]
+  tmp <- mkdtemp "psql-test"
+  let dbPath = tmp </> "db"
 
-        -- ACT
-        -- Create a task worker which toggles the boolean IORef
-        ret <- createTaskWorker c (toggleBoolIORef boolRef False) "Test-Worker"
+  withDB dbPath $ \c ->
+    hspec $ around_ (withTables c) $ do
+      describe "taskWorker" $ do
+        -- TEST 1
+        --   Creates a task that toggles a boolean. Tests functionally that everything works.
+        it "works functionally, bare minimum test" $ do
+          -- SETUP
+          -- Create an IORef which will be toggled by the worker
+          -- Add a task to the table
+          let
+            initBool = False
+          boolRef <- newIORef initBool
+          insertTestTasks c [ createTask 1 ]
 
-        -- ASSERT
-        -- The worker should have updated the database with its task result
-        -- The worker should not have failed
-        -- The worker should have completed its task
-        maybeTask <- justOneTestTask c
-        case maybeTask of
-          Nothing -> do
-            fail "There should have been 1 row in the tasks table"
-            pure ()
-          Just (TestTask (Task _ result checkedOutBy) _) -> do
-            result `shouldBe` Just True
-            checkedOutBy `shouldBe` Nothing
-        ret `shouldBe` True
-        readIORef boolRef `shouldReturn` not initBool
+          -- ACT
+          -- Create a task worker which toggles the boolean IORef
+          ret <- createTaskWorker c (toggleBoolIORef boolRef False) "Test-Worker"
 
-      -- TEST 2
-      --   Creates a task that fails. Tests that even on failure, the task is checked out by the worker.
-      it "fails, keeps row in database" $ \c -> do
-        -- SETUP
-        -- Create an IORef bool that should be toggled by the worker task.
-        -- Insert a single task into the table
-        let
-          initBool = False
-          workerName = "Test-Worker"
-        boolRef <- newIORef initBool
-        insertTestTasks c [ createTask 1 ]
+          -- ASSERT
+          -- The worker should have updated the database with its task result
+          -- The worker should not have failed
+          -- The worker should have completed its task
+          maybeTask <- justOneTestTask c
+          case maybeTask of
+            Nothing -> do
+              fail "There should have been 1 row in the tasks table"
+              pure ()
+            Just (TestTask (Task _ result checkedOutBy) _) -> do
+              result `shouldBe` Just True
+              checkedOutBy `shouldBe` Nothing
+          ret `shouldBe` True
+          readIORef boolRef `shouldReturn` not initBool
 
-        -- ACT
-        -- Create a task worker which fails (throws an exception)
-        e <- try $ createTaskWorker c (toggleBoolIORef boolRef True) workerName
+        -- TEST 2
+        --   Creates a task that fails. Tests that even on failure, the task is checked out by the worker.
+        it "fails, keeps row in database" $ do
+          -- SETUP
+          -- Create an IORef bool that should be toggled by the worker task.
+          -- Insert a single task into the table
+          let
+            initBool = False
+            workerName = "Test-Worker"
+          boolRef <- newIORef initBool
+          insertTestTasks c [ createTask 1 ]
 
-        -- ASSERT
-        -- The task should have failed with a `TestException`
-        -- The worker should have updated the database with its task result
-        -- The worker failed its task, so the ioref should still be false
-        e `shouldBe` Left TestException
-        maybeTask <- justOneTestTask c
-        case maybeTask of
-          Nothing -> do
-            fail "There should have been 1 row in the tasks table"
-            pure ()
-          Just (TestTask (Task _ _ checkedOutBy) _) -> checkedOutBy `shouldBe` Just workerName
-        readIORef boolRef `shouldReturn` initBool
+          -- ACT
+          -- Create a task worker which fails (throws an exception)
+          e <- try $ createTaskWorker c (toggleBoolIORef boolRef True) workerName
 
-      -- TEST 3
-      --   Adds two tasks to the table, then creates two workers. Both these workers will be blocked from
-      --   finishing their task by reading an MVar. By this time they should have checked out one task each.
-      --   Once this has been verified, we unblock both tasks, and let them finish.
-      --   NOTE: We will require two connections for this test,
-      --         since Postgresql shows a warning when we run 2 transactions from the same connection
-      it "works concurrently, 2 workers" $ \c1 -> do
-        -- SETUP
-        -- Create an MVar which will be used to block both the workers once they have retrieved tasks from the table.
-        -- Create an IORef Int which will be used inside worker task as an increment action
-        -- Add two separate tasks to the table
-        -- Create the second connection
-        let
-          initCount = 0
-          workerNames = ["Test-Worker 1", "Test-Worker 2"]
-        awakenMVar <- newEmptyMVar :: IO (MVar ())
-        countRef <- newIORef initCount
-        insertTestTasks c1 $ map createTask [1, 2]
-        c2 <- connect defaultConnectInfo
+          -- ASSERT
+          -- The task should have failed with a `TestException`
+          -- The worker should have updated the database with its task result
+          -- The worker failed its task, so the ioref should still be false
+          e `shouldBe` Left TestException
+          maybeTask <- justOneTestTask c
+          case maybeTask of
+            Nothing -> do
+              fail "There should have been 1 row in the tasks table"
+              pure ()
+            Just (TestTask (Task _ _ checkedOutBy) _) -> checkedOutBy `shouldBe` Just workerName
+          readIORef boolRef `shouldReturn` initBool
 
-        -- ACT
-        -- Spawn two workers in separate threads
-        let
-          work = const $ pure $ do
-            -- Block on awakenMVar
-            () <- readMVar awakenMVar
-            atomicModifyIORef countRef (\i -> (i+1, ()))
-            pure $ pure True
-        zipWithM_ (spawnTaskWorker work) [c1, c2] workerNames
+        -- TEST 3
+        --   Adds two tasks to the table, then creates two workers. Both these workers will be blocked from
+        --   finishing their task by reading an MVar. By this time they should have checked out one task each.
+        --   Once this has been verified, we unblock both tasks, and let them finish.
+        --   NOTE: We will require two connections for this test,
+        --         since Postgresql shows a warning when we run 2 transactions from the same connection
+        it "works concurrently, 2 workers" $ do
+          -- SETUP
+          -- Create an MVar which will be used to block both the workers once they have retrieved tasks from the table.
+          -- Create an IORef Int which will be used inside worker task as an increment action
+          -- Add two separate tasks to the table
+          -- Create the second connection
+          let
+            initCount = 0
+            workerNames = ["Test-Worker 1", "Test-Worker 2"]
+          awakenMVar <- newEmptyMVar :: IO (MVar ())
+          countRef <- newIORef initCount
+          insertTestTasks c $ map createTask [1, 2]
+          withDB dbPath $ \c2 -> do
 
-        -- ASSERT
-        -- Wait for both workers to block
-        -- Both workers should have retrieved tasks from the table and blocked by now
-        -- Both tasks should have been checkedout
-        threadDelay $ 3 * timeForOneTask
-        tasks <- allTestTasks c1
-        sort (map (_taskCheckedOutBy . _taskDetails) tasks) `shouldBe` map Just workerNames
+            -- ACT
+            -- Spawn two workers in separate threads
+            let
+              work = const $ pure $ do
+                -- Block on awakenMVar
+                () <- readMVar awakenMVar
+                atomicModifyIORef countRef (\i -> (i+1, ()))
+                pure $ pure True
+            zipWithM_ (spawnTaskWorker work) [c, c2] workerNames
 
-        -- ACT
-        -- Unblock both workers
-        -- Wait for both workers to finish
-        putMVar awakenMVar ()
-        threadDelay $ 3 * timeForOneTask
+            -- ASSERT
+            -- Wait for both workers to block
+            -- Both workers should have retrieved tasks from the table and blocked by now
+            -- Both tasks should have been checkedout
+            threadDelay $ 3 * timeForOneTask
+            tasks <- allTestTasks c
+            sort (map (_taskCheckedOutBy . _taskDetails) tasks) `shouldBe` map Just workerNames
 
-        -- ASSERT
-        -- Both tasks should have been completed by now, and updated in the table
-        -- Both tasks should have `checked_out_by` set to null
-        -- Both tasks' result should be Just True
-        -- The increment task should also have been completed
-        tasks <- allTestTasks c1
-        map (_taskCheckedOutBy . _taskDetails) tasks `shouldBe` replicate 2 Nothing
-        map (_taskResult . _taskDetails) tasks `shouldBe` replicate 2 (Just True)
-        readIORef countRef `shouldReturn` (initCount + 2)
-        close c2
+            -- ACT
+            -- Unblock both workers
+            -- Wait for both workers to finish
+            putMVar awakenMVar ()
+            threadDelay $ 3 * timeForOneTask
 
-      -- TEST 4
-      --   Create a worker with a task that will never run, since the table only has
-      --   completed or already checked-out tasks.
-      it "never picks up a checked out or completed task" $ \c -> do
-        -- SETUP
-        -- Create a boolean IORef that will be modified by the worker
-        -- Add two separate tasks to the table
-        let
-          initBool = False
-          tasks =
-            [ TestTask (Task 1 (Just True) Nothing) 1 -- Completed Task
-            , TestTask (Task 2 Nothing (Just "Test-Worker 1")) 2 -- Task already checked out
-            ]
-        boolRef <- newIORef initBool
-        insertTestTasks c tasks
+            -- ASSERT
+            -- Both tasks should have been completed by now, and updated in the table
+            -- Both tasks should have `checked_out_by` set to null
+            -- Both tasks' result should be Just True
+            -- The increment task should also have been completed
+            tasks <- allTestTasks c
+            map (_taskCheckedOutBy . _taskDetails) tasks `shouldBe` replicate 2 Nothing
+            map (_taskResult . _taskDetails) tasks `shouldBe` replicate 2 (Just True)
+            readIORef countRef `shouldReturn` (initCount + 2)
 
-        -- ACT
-        -- Spawn a worker in a separate thread
-        spawnTaskWorker (toggleBoolIORef boolRef False) c "Test-Worker 2"
+        -- TEST 4
+        --   Create a worker with a task that will never run, since the table only has
+        --   completed or already checked-out tasks.
+        it "never picks up a checked out or completed task" $ do
+          -- SETUP
+          -- Create a boolean IORef that will be modified by the worker
+          -- Add two separate tasks to the table
+          let
+            initBool = False
+            tasks =
+              [ TestTask (Task 1 (Just True) Nothing) 1 -- Completed Task
+              , TestTask (Task 2 Nothing (Just "Test-Worker 1")) 2 -- Task already checked out
+              ]
+          boolRef <- newIORef initBool
+          insertTestTasks c tasks
 
-        -- ASSERT
-        -- Wait for some time
-        -- Our IORef should still contain its initial value
-        -- Both the tasks should not have been modified
-        threadDelay $ 3 * timeForOneTask
-        readIORef boolRef `shouldReturn` initBool
-        tasksInDb <- allTestTasks c
-        tasksInDb == tasks `shouldBe` True
+          -- ACT
+          -- Spawn a worker in a separate thread
+          spawnTaskWorker (toggleBoolIORef boolRef False) c "Test-Worker 2"
 
-      -- TEST 5
-      -- Creates some workers, and a bigger number of tasks. Workers run repeatedly until they run out of tasks.
-      -- All tasks should be processed, and each task should only be processed once.
-      it "" $ \c -> do
-        -- SETUP
-        -- Create a limited number of tasks
-        -- Create an IORef that stores a map, from Task IDs (Int32) -> Set of worker names that processed the task (Set Text)
-        let
-          taskCount = 1000
-          threadCount = 8
-          tasks = map createTask [1..fromIntegral taskCount]
-        mapRef <- newIORef (M.empty :: M.Map Int32 (S.Set Text))
+          -- ASSERT
+          -- Wait for some time
+          -- Our IORef should still contain its initial value
+          -- Both the tasks should not have been modified
+          threadDelay $ 3 * timeForOneTask
+          readIORef boolRef `shouldReturn` initBool
+          tasksInDb <- allTestTasks c
+          tasksInDb == tasks `shouldBe` True
 
-        -- ACT
-        -- Insert all the tasks into the table
-        -- Wait for some time
-        -- Spawn 8 threads, each thread repeatedly runs a taskWorker, which updates the map with an entry for the task along with the worker name.
-        let
-          work workerName testTaskId = pure $ do
-            atomicModifyIORef mapRef (\old -> (M.insertWith S.union testTaskId (S.singleton workerName) old, ()))
-            pure $ pure True
-          repeatWork conn threadId = do
-            let workerName = "Task-Worker " <> pack (show threadId)
-            void $ forkIO $ do
+        -- TEST 5
+        -- Creates some workers, and a bigger number of tasks. Workers run repeatedly until they run out of tasks.
+        -- All tasks should be processed, and each task should only be processed once.
+        it "runs parallel taskWorkers on a number of tasks" $ do
+          -- SETUP
+          -- Create a limited number of tasks
+          -- Create an IORef that stores a map, from Task IDs (Int32) -> Set of worker names that processed the task (Set Text)
+          let
+            taskCount = 1000
+            threadCount = 8
+            tasks = map createTask [1..fromIntegral taskCount]
+          mapRef <- newIORef (M.empty :: M.Map Int32 (S.Set Text))
+
+          -- ACT
+          -- Insert all the tasks into the table
+          -- Wait for some time
+          -- Spawn a number of threads, each thread repeatedly runs a taskWorker,
+          --   which updates the map with an entry for the task along with the worker name.
+          let
+            work workerName testTaskId = pure $ do
+              atomicModifyIORef mapRef (\old -> (M.insertWith S.union testTaskId (S.singleton workerName) old, ()))
+              pure $ pure True
+            repeatWork conn threadId = do
+              let workerName = "Task-Worker " <> pack (show threadId)
               b <- createTaskWorker conn (work workerName) workerName
               if b
                 then repeatWork conn threadId
-                else close conn
-        insertTestTasks c tasks
-        threadDelay $ 3 * timeForOneTask
-        forM_ [1..threadCount] $ \tid -> do
-          conn <- connect defaultConnectInfo
-          repeatWork conn tid
+                else pure ()
+          insertTestTasks c tasks
+          threadDelay $ 3 * timeForOneTask
+          forM_ [1..threadCount] $ \tid ->
+            void $ forkIO $
+              withDB dbPath $ \conn ->
+                repeatWork conn tid
 
-        -- ASSERT
-        -- Wait for 5 seconds
-        -- All tasks' `checked out by` should have been set to null
-        -- All tasks should have the result of the work set, as Just True
-        -- Each task should have been checked out at some time, with an entry in the map
-        -- Each task should have been checked out only once.
-        threadDelay $ (taskCount * timeForOneTask) `div` threadCount
-        taskMap <- readIORef mapRef
-        tasks <- allTestTasks c
-        map (_taskCheckedOutBy . _taskDetails) tasks `shouldBe` replicate taskCount Nothing
-        map (_taskResult . _taskDetails) tasks `shouldBe` replicate taskCount (Just True)
-        M.keys taskMap `shouldBe` [1..fromIntegral taskCount]
-        all (\set -> S.size set == 1) (M.elems taskMap) `shouldBe` True
+          -- ASSERT
+          -- Wait for some time
+          -- All tasks' `checked out by` should have been set to null
+          -- All tasks should have the result of the work set, as Just True
+          -- Each task should have been checked out at some time, with an entry in the map
+          -- Each task should have been checked out only once.
+          threadDelay $ (taskCount * timeForOneTask) `div` threadCount
+          taskMap <- readIORef mapRef
+          tasks <- allTestTasks c
+          map (_taskCheckedOutBy . _taskDetails) tasks `shouldBe` replicate taskCount Nothing
+          map (_taskResult . _taskDetails) tasks `shouldBe` replicate taskCount (Just True)
+          M.keys taskMap `shouldBe` [1..fromIntegral taskCount]
+          all (\set -> S.size set == 1) (M.elems taskMap) `shouldBe` True

--- a/beam/test/Test.hs
+++ b/beam/test/Test.hs
@@ -27,9 +27,6 @@ import Rhyolite.Task.Beam.Worker
 import Types
 import Utils
 
--- TODO : Use beam-automigrate
--- TODO : Check how we can achieve complete haddock coverage even with lens
-
 setupTable :: Pool Connection -> IO (Pool Connection)
 setupTable pool = do
   withResource pool $ \dbConn ->

--- a/beam/test/Test.hs
+++ b/beam/test/Test.hs
@@ -1,0 +1,105 @@
+{-# Language DeriveAnyClass #-}
+{-# Language DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# Language TemplateHaskell #-}
+{-# Language TypeFamilies #-}
+
+module Main where
+
+import Control.Exception (bracket)
+import Control.Lens.TH
+import Control.Monad.Logger
+import Control.Monad.Trans.Reader
+import Data.IORef
+import Data.Int (Int32)
+import Data.Maybe (isJust)
+import Data.String (fromString)
+import Data.Text
+
+import Database.Beam
+import Database.Beam.Postgres
+import Database.PostgreSQL.Simple
+
+import Test.Hspec
+
+import Database.PostgreSQL.Serializable
+import Rhyolite.Task.Beam
+import Rhyolite.Task.Beam.Worker
+
+data TestTaskT f = TestTask
+  { _taskDetails :: Task Text Bool f
+  , _taskId :: C f Int32
+  } deriving (Generic, Beamable)
+
+makeLenses ''TestTaskT
+
+type TestTask = TestTaskT Identity
+type TestTaskId = PrimaryKey TestTaskT Identity
+
+instance Table TestTaskT where
+   data PrimaryKey TestTaskT f = TestTaskId (Columnar f Int32) deriving (Generic, Beamable)
+   primaryKey = TestTaskId . _taskId
+
+newtype TestTasksDb f = TestTasksDb
+  { _tasks :: f (TableEntity TestTaskT) }
+    deriving (Generic, Database be)
+
+tasksDb :: DatabaseSettings be TestTasksDb
+tasksDb = defaultDbSettings `withDbModification`
+  dbModification {
+    _tasks =
+      modifyTableFields (TestTask taskFields "id")
+  }
+  where
+    taskFields = Task (fromString "payload") (fromString "result") (fromString "checked_out_by")
+
+setupDB :: IO Connection
+setupDB = do
+  dbConn <- connect defaultConnectInfo
+  execute dbConn "create table tasks (payload varchar(30) NOT NULL, result boolean, checked_out_by varchar(30), id integer PRIMARY KEY);" ()
+  pure dbConn
+
+closeDB :: Connection -> IO ()
+closeDB dbConn = do
+  execute dbConn "drop table tasks;" ()
+  close dbConn
+
+withDB :: (Connection -> IO ()) -> IO ()
+withDB = bracket setupDB closeDB
+
+instance MonadLogger IO where
+  monadLoggerLog _ _ _ msg = print $ toLogStr msg
+
+instance MonadLoggerIO IO where
+  askLoggerIO = pure (\_ _ _ logStr -> print logStr)
+
+main :: IO ()
+main = hspec $ around withDB $ do
+  describe "taskWorker" $ do
+    it "works functionally, bare minimum test" $ \c -> do
+      ioBool <- newIORef False
+
+      runBeamPostgres c $ runInsert $
+        insert (_tasks tasksDb) $
+        insertValues
+          [ TestTask (Task "Toggle an IORef Bool" Nothing Nothing) 1 ]
+
+      -- The worker should not have failed
+      taskWorker c (_tasks tasksDb) (val_ True) taskDetails (\_ -> do
+        pure $ do
+          atomicModifyIORef ioBool (const (True, ()))
+          pure $ pure True
+        ) "Test-Worker" `shouldReturn` True
+
+      maybeTask <- runBeamPostgres c $ runSelectReturningOne $
+        select $ all_ (_tasks tasksDb)
+
+      -- The worker should have updated the database with its task result
+      case maybeTask of
+        Nothing -> do
+          fail "There should have been 1 row in the tasks table"
+          pure ()
+        Just (TestTask (Task _ result _) _) -> result `shouldBe` Just True
+
+      -- The worker should have completed its task
+      readIORef ioBool `shouldReturn` True

--- a/beam/test/Types.hs
+++ b/beam/test/Types.hs
@@ -1,9 +1,11 @@
+{-# Language DataKinds #-}
 {-# Language DeriveAnyClass #-}
 {-# Language DeriveGeneric #-}
 {-# Language FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# Language StandaloneDeriving #-}
 {-# Language TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 {-# Language TypeFamilies #-}
 
 module Types where
@@ -12,9 +14,12 @@ import Control.Exception
 import Control.Lens
 import Control.Monad.Logger
 import Data.Int (Int32)
+import Data.Proxy
 import Data.String (fromString)
 import Data.Text (Text)
 import Database.Beam
+import qualified Database.Beam.AutoMigrate as BA
+import Database.Beam.Postgres
 
 import Rhyolite.Task.Beam
 
@@ -49,6 +54,12 @@ tasksDb = defaultDbSettings `withDbModification`
   }
   where
     taskFields = Task (fromString "payload") (fromString "result") (fromString "checked_out_by")
+
+tasksDbPostgres :: BA.AnnotatedDatabaseSettings Postgres TestTasksDb
+tasksDbPostgres = BA.defaultAnnotatedDbSettings tasksDb
+
+taskSchema :: BA.Schema
+taskSchema = BA.fromAnnotatedDbSettings tasksDbPostgres (Proxy @'[])
 
 data TestException = TestException
    deriving (Eq, Show, Typeable)

--- a/beam/test/Types.hs
+++ b/beam/test/Types.hs
@@ -19,7 +19,7 @@ import Database.Beam
 import Rhyolite.Task.Beam
 
 data TestTaskT f = TestTask
-  { _taskDetails :: Task Int32 Bool f
+  { _taskDetails :: Task Int32 Bool Text f
   , _taskId :: C f Int32
   } deriving (Generic, Beamable)
 

--- a/beam/test/Types.hs
+++ b/beam/test/Types.hs
@@ -1,0 +1,62 @@
+{-# Language DeriveAnyClass #-}
+{-# Language DeriveGeneric #-}
+{-# Language FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# Language StandaloneDeriving #-}
+{-# Language TemplateHaskell #-}
+{-# Language TypeFamilies #-}
+
+module Types where
+
+import Control.Exception
+import Control.Lens
+import Control.Monad.Logger
+import Data.Int (Int32)
+import Data.String (fromString)
+import Data.Text (Text)
+import Database.Beam
+
+import Rhyolite.Task.Beam
+
+data TestTaskT f = TestTask
+  { _taskDetails :: Task Int32 Bool f
+  , _taskId :: C f Int32
+  } deriving (Generic, Beamable)
+
+makeLenses ''TestTaskT
+
+type TestTask = TestTaskT Identity
+type TestTaskId = PrimaryKey TestTaskT Identity
+
+deriving instance Eq TestTask
+
+instance Table TestTaskT where
+   data PrimaryKey TestTaskT f = TestTaskId (Columnar f Int32) deriving (Generic, Beamable)
+   primaryKey = TestTaskId . _taskId
+
+createTask :: Int32 -> TestTask
+createTask i = TestTask (Task i Nothing Nothing) i
+
+newtype TestTasksDb f = TestTasksDb
+  { _tasks :: f (TableEntity TestTaskT) }
+    deriving (Generic, Database be)
+
+tasksDb :: DatabaseSettings be TestTasksDb
+tasksDb = defaultDbSettings `withDbModification`
+  dbModification {
+    _tasks =
+      modifyTableFields (TestTask taskFields "id")
+  }
+  where
+    taskFields = Task (fromString "payload") (fromString "result") (fromString "checked_out_by")
+
+data TestException = TestException
+   deriving (Eq, Show, Typeable)
+
+instance Exception TestException
+
+instance MonadLogger IO where
+  monadLoggerLog _ _ _ msg = print $ toLogStr msg
+
+instance MonadLoggerIO IO where
+  askLoggerIO = pure (\_ _ _ logStr -> print logStr)

--- a/beam/test/Utils.hs
+++ b/beam/test/Utils.hs
@@ -1,0 +1,44 @@
+{-# Language FlexibleContexts #-}
+module Utils where
+
+import Control.Concurrent (forkIO)
+import Control.Exception (throw)
+import Control.Monad (void, when)
+import Data.Int (Int32)
+import Data.IORef
+import Data.Text (Text)
+import Database.Beam
+import Database.Beam.Backend.SQL.SQL92
+import Database.Beam.Postgres
+import Database.Beam.Postgres.Syntax
+import Database.PostgreSQL.Simple
+import Database.PostgreSQL.Serializable
+import Rhyolite.Task.Beam.Worker
+import Types
+
+type Work = Int32 -> Serializable (IO (Serializable Bool))
+
+insertTestTasks :: Connection -> [TestTask] -> IO ()
+insertTestTasks c = runBeamPostgres c . runInsert . insert (_tasks tasksDb) . insertValues
+
+createTaskWorker :: Connection -> Work -> Text -> IO Bool
+createTaskWorker c = taskWorker c (_tasks tasksDb) (val_ True) taskDetails
+
+allTestTasks :: Connection -> IO [TestTask]
+allTestTasks c =
+  runBeamPostgres c $ runSelectReturningList $
+    select $ all_ (_tasks tasksDb)
+
+justOneTestTask :: Connection -> IO (Maybe TestTask)
+justOneTestTask c =
+  runBeamPostgres c $ runSelectReturningOne $
+    select $ all_ (_tasks tasksDb)
+
+spawnTaskWorker :: Work -> Connection -> Text -> IO ()
+spawnTaskWorker work conn = void . forkIO . void . createTaskWorker conn work
+
+toggleBoolIORef :: IORef Bool -> Bool -> Work
+toggleBoolIORef boolRef flag = const $ pure $ do
+  when flag $ throw TestException
+  atomicModifyIORef boolRef (\b -> (not b, ()))
+  pure $ pure True

--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,6 @@
 packages:
   backend/
+  beam/
   common/
   semimap/
   email/

--- a/default.nix
+++ b/default.nix
@@ -65,6 +65,7 @@ let
   haskellOverrides = lib.foldr lib.composeExtensions (_: _: {}) [
     (self: super: lib.mapAttrs (name: path: self.callCabal2nix name path {}) overrideSrcs)
     (self: super: {
+      beam-automigrate = haskellLib.doJailbreak super.beam-automigrate;
       bytestring-trie = haskellLib.dontCheck super.bytestring-trie;
       dependent-monoidal-map = haskellLib.doJailbreak super.dependent-monoidal-map;
       gargoyle-postgresql-nix = haskellLib.overrideCabal super.gargoyle-postgresql-nix { librarySystemDepends = [ pkgs.postgresql ]; };

--- a/default.nix
+++ b/default.nix
@@ -97,13 +97,12 @@ let
       } {};
       standalone-haddock = self.callHackage "standalone-haddock" "1.4.0.0" {};
 
-      # On darwin we need to ensure that 'locale' is available for 'initdb'.
-      rhyolite-beam-task-worker = haskellLib.overrideCabal super.rhyolite-beam-task-worker (drv: {
-        testSystemDepends = (drv.testSystemDepends or []) ++
-        [ (lib.optional pkgs.stdenv.hostPlatform.isDarwin pkgs.darwin.locale)
-          (lib.optional pkgs.stdenv.hostPlatform.isDarwin pkgs.unixtools.locale)
-        ];
-      });
+      # 'locale' is broken on nix darwin which is required by postgres 'initdb'
+      rhyolite-beam-task-worker = if pkgs.stdenv.hostPlatform.isDarwin
+      then
+        haskellLib.dontCheck super.rhyolite-beam-task-worker
+      else
+        super.rhyolite-beam-task-worker;
     })
   ];
 

--- a/default.nix
+++ b/default.nix
@@ -68,7 +68,9 @@ let
       beam-automigrate = haskellLib.doJailbreak super.beam-automigrate;
       bytestring-trie = haskellLib.dontCheck super.bytestring-trie;
       dependent-monoidal-map = haskellLib.doJailbreak super.dependent-monoidal-map;
-      gargoyle-postgresql-nix = haskellLib.overrideCabal super.gargoyle-postgresql-nix { librarySystemDepends = [ pkgs.postgresql ]; };
+      gargoyle-postgresql-nix = haskellLib.overrideCabal super.gargoyle-postgresql-nix {
+        librarySystemDepends = [ pkgs.postgresql ];
+      };
       postgresql-simple = haskellLib.dontCheck (
           haskellLib.overrideCabal super.postgresql-simple {
             revision = null;
@@ -95,6 +97,13 @@ let
       } {};
       standalone-haddock = self.callHackage "standalone-haddock" "1.4.0.0" {};
 
+      # On darwin we need to ensure that 'locale' is available for 'initdb'.
+      rhyolite-beam-task-worker = haskellLib.overrideCabal super.rhyolite-beam-task-worker (drv: {
+        testSystemDepends = (drv.testSystemDepends or []) ++
+        [ (lib.optional pkgs.stdenv.hostPlatform.isDarwin pkgs.darwin.locale)
+          (lib.optional pkgs.stdenv.hostPlatform.isDarwin pkgs.unixtools.locale)
+        ];
+      });
     })
   ];
 

--- a/default.nix
+++ b/default.nix
@@ -15,7 +15,7 @@ let
   # Local packages. We override them below so that other packages can use them.
   rhyolitePackages = {
     rhyolite-backend = ./backend;
-    rhyolite-beam = ./beam;
+    rhyolite-beam-task-worker = ./beam;
     rhyolite-notify-listen = ./notify-listen/notify-listen;
     rhyolite-notify-listen-beam = ./notify-listen/notify-listen-beam;
     psql-simple-class = ./psql-extras/psql-simple-class;

--- a/default.nix
+++ b/default.nix
@@ -15,6 +15,7 @@ let
   # Local packages. We override them below so that other packages can use them.
   rhyolitePackages = {
     rhyolite-backend = ./backend;
+    rhyolite-beam = ./beam;
     rhyolite-notify-listen = ./notify-listen/notify-listen;
     rhyolite-notify-listen-beam = ./notify-listen/notify-listen-beam;
     psql-simple-class = ./psql-extras/psql-simple-class;

--- a/psql-extras/psql-serializable/src/Database/PostgreSQL/Serializable.hs
+++ b/psql-extras/psql-serializable/src/Database/PostgreSQL/Serializable.hs
@@ -53,6 +53,8 @@ runSerializable pool logger (Serializable act) = liftIO $ withResource pool $ \c
   Pg.withTransactionSerializable c $
     runLoggerLoggingT (runReaderT act c) logger
 
+-- | Run a @Serializable@ inside a Postgres Transaction. Note that this function does not create a transaction on
+-- its own, that responsibility lies with the function that invokes it.
 runSerializableInsideTransaction :: forall a m. (MonadIO m) => Pg.Connection -> Logger -> Serializable a -> m a
 runSerializableInsideTransaction conn logger (Serializable act) = liftIO $ runLoggerLoggingT (runReaderT act conn) logger
 

--- a/test/rhyolite-test-suite.cabal
+++ b/test/rhyolite-test-suite.cabal
@@ -19,6 +19,7 @@ executable rhyolite-test-suite
     , psql-simple-class
     , psql-simple-groundhog
     , rhyolite-backend
+    , rhyolite-beam-task-worker
     , rhyolite-common
     , rhyolite-email
     , rhyolite-frontend


### PR DESCRIPTION
This PR contains beam versions for `taskWorker` and the data type `Task`. Some things to note:

- `Task` used to be an `embedded` type in GroundHog. In Beam, I have chosen to implement this as a Data Family. All tables that have tasks are supposed to implement the `HasTasks` class. This essentially means that a table implementing `HasTasks` will have 2 columns, just as the `Task` embedded type.
- Previously, we depended on `Serializable` for creating SQL transactions. To keep a similar interface, I have kept the type of the incoming action same, it is still `(a -> Serializable (m (Serializable b)))`. However, since beam uses `MonadBeam`, I have written a new function that unwraps the `Serializable` into an `IO` action.
- Support for transactions is still provided by `postgresql-simple`.
- `withWorker` and `withConcurrentWorkers` are the same.