### PR TITLE
account: move PasswordResetToken to rhyolite-account-types

### DIFF
--- a/account/backend/src/Rhyolite/Backend/Account.hs
+++ b/account/backend/src/Rhyolite/Backend/Account.hs
@@ -12,7 +12,6 @@ module Rhyolite.Backend.Account
   , ensureAccountExists
   , setAccountPasswordHash
   , makePasswordHash
-  , PasswordResetToken (..)
   , passwordResetToken
   , newNonce
   , resetPassword
@@ -152,14 +151,6 @@ resetPassword accountTable aid nonce pwhash = do
         setAccountPasswordHash accountTable aid pwhash
         return $ Just aid
       else fail "nonce mismatch"
-
-newtype PasswordResetToken = PasswordResetToken
-  { unPasswordResetToken :: (PrimaryKey Account Identity, UTCTime)
-  }
-  deriving (Generic)
-
-instance ToJSON PasswordResetToken
-instance FromJSON PasswordResetToken
 
 passwordResetToken
   :: MonadIO m

--- a/account/types/src/Rhyolite/Account.hs
+++ b/account/types/src/Rhyolite/Account.hs
@@ -43,3 +43,12 @@ deriving instance Show (PrimaryKey Account Identity)
 
 instance ToJSON (PrimaryKey Account Identity)
 instance FromJSON (PrimaryKey Account Identity)
+
+
+newtype PasswordResetToken = PasswordResetToken
+  { unPasswordResetToken :: (PrimaryKey Account Identity, UTCTime)
+  }
+  deriving (Generic)
+
+instance ToJSON PasswordResetToken
+instance FromJSON PasswordResetToken


### PR DESCRIPTION
1. Types should go to rhyolite-account-types.
2. This token may be required by common or frontend.