### PR TITLE
email: add orphaned instances for Mail

### DIFF
--- a/email/rhyolite-email.cabal
+++ b/email/rhyolite-email.cabal
@@ -16,11 +16,14 @@ extra-source-files:
   email.css
 
 library
-  exposed-modules:  Rhyolite.Email
+  exposed-modules:
+      Rhyolite.Email
+    , Rhyolite.Email.Orphans
   build-depends:
+      base
     , aeson
-    , base
     , blaze-html
+    , bytestring-aeson-orphans
     , data-default
     , file-embed
     , HaskellNet

--- a/email/src/Rhyolite/Email/Orphans.hs
+++ b/email/src/Rhyolite/Email/Orphans.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Rhyolite.Email.Orphans where
+
+import ByteString.Aeson.Orphans ()
+import Data.Aeson
+import Data.Aeson.TH
+import qualified Network.Mail.Mime as Mail
+
+deriveJSON defaultOptions ''Mail.Address
+deriveJSON defaultOptions ''Mail.Disposition
+deriveJSON defaultOptions ''Mail.Encoding
+deriveJSON defaultOptions ''Mail.Part
+deriveJSON defaultOptions ''Mail.PartContent
+deriveJSON defaultOptions ''Mail.Mail

--- a/email/src/Rhyolite/Email/Orphans.hs
+++ b/email/src/Rhyolite/Email/Orphans.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Rhyolite.Email.Orphans where
@@ -14,3 +15,5 @@ deriveJSON defaultOptions ''Mail.Encoding
 deriveJSON defaultOptions ''Mail.Part
 deriveJSON defaultOptions ''Mail.PartContent
 deriveJSON defaultOptions ''Mail.Mail
+
+deriving instance Read Mail.Address


### PR DESCRIPTION
These instances are required to store Mail types inside database table. E.g. for email task workers.
Read instance for Address is useful when we want to read it as part of configs.