### PR TITLE
Add lower level helpers to notify-listen-beam 

### DIFF
--- a/notify-listen/notify-listen-beam/CHANGELOG.md
+++ b/notify-listen/notify-listen-beam/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Revision history for rhyolite-notify-listen-beam
 
-## 0.1.0.0 -- YYYY-mm-dd
+## Unreleased
+
+* Add some new combinators for working with an {insert, update, delete} statement that returns arbitrary data
+
+* Breaking changes:
+  * Change the type of deleteAndNotify to account for deletions that can fail.
+
+## 0.1.0.0
 
 * First version. Released on an unsuspecting world.

--- a/notify-listen/notify-listen-beam/rhyolite-notify-listen-beam.cabal
+++ b/notify-listen/notify-listen-beam/rhyolite-notify-listen-beam.cabal
@@ -28,6 +28,7 @@ library
     , beam-postgres
     , constraints
     , constraints-extras
+    , dependent-sum
     , psql-simple-beam
     , psql-simple-class
     , rhyolite-common

--- a/notify-listen/notify-listen-beam/src/Rhyolite/DB/NotifyListen/Beam.hs
+++ b/notify-listen/notify-listen-beam/src/Rhyolite/DB/NotifyListen/Beam.hs
@@ -330,13 +330,3 @@ runPgDeleteReturningListWithNotify toNotification statement = do
   rs <- Pg.runPgDeleteReturningList statement
   mapM_ (notify' NotificationType_Delete) (toNotification rs)
   pure rs
-
--- | Variation of 'notify' which takes the notification tag and payload already combined
--- as a 'DSum'
-notify'
-  :: (Has' ToJSON tag Identity, ForallF ToJSON tag, Psql m)
-  => NotificationType
-  -> DSum tag Identity
-  -> m ()
-notify' nType (n :=> Identity a) = notify nType n a
-


### PR DESCRIPTION
Namely:
  * runPgInsertReturningListWithNotify
  * runPgUpdateReturningListWithNotify
  * runPgDeleteReturningListWithNotify

The lower level helpers do not assume anything about the statement that
will be executed. Instead, they take as a parameter the function for
converting the result of the statement to a list of notifications.

Some of the higher level helpers which construct their own queries have
been reimplemented using the lower level helpers and more efficient
returns.

I have taken the opportunity of removing a constraint synonym for a pile
of beam noise by using the constraint synonyms beam itself uses. This
ought to be a little more useful for figuring out how to fulfill these
constraints when they aren't automatically satisfied.

In addition, this PR adds `notify'` to notify-listen since it was convenient for implementing the above.

I have made a breaking change to the type of `deleteAndNotify`: Before it would notify and return a primary key unconditionally, but that doesn't make sense to me. It's possible, for example, to delete a row that doesn't exist. That should not emit a notification.