### PR TITLE
Update README to use newer default.nix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,31 @@ Rhyolite provides:
    haskellOverrides. You can base it off of this example:
 
    ```
-   { system ? builtins.currentSystem # TODO: Get rid of this system cruft
-   , iosSdkVersion ? "10.2"
-   }:
-   with import ./.obelisk/impl { inherit system iosSdkVersion; };
+   { system ? builtins.currentSystem, obelisk ? import ./.obelisk/impl {
+     inherit system;
+     iosSdkVersion = "13.2";
+ 
+     # You must accept the Android Software Development Kit License Agreement at
+     # https://developer.android.com/studio/terms in order to build Android apps.
+     # Uncomment and set this to `true` to indicate your acceptance:
+     # config.android_sdk.accept_license = false;
+ 
+     # In order to use Let's Encrypt for HTTPS deployments you must accept
+     # their terms of service at https://letsencrypt.org/repository/.
+     # Uncomment and set this to `true` to indicate your acceptance:
+     # terms.security.acme.acceptTerms = false;
+   } }:
+   with obelisk;
    project ./. ({ pkgs, hackGet, ... }@args: {
-
-     overrides = pkgs.lib.composeExtensions (pkgs.callPackage (hackGet ./dep/rhyolite) args).haskellOverrides
-       (self: super: with pkgs.haskell.lib; {
-         # Your custom overrides go here.
-       });
-
+ 
+     overrides = pkgs.lib.composeExtensions
+       (pkgs.callPackage (hackGet ./dep/rhyolite) args).haskellOverrides
+       (self: super:
+         with pkgs.haskell.lib;
+         {
+           # Your custom overrides go here.
+         });
+ 
      android.applicationId = "systems.obsidian.obelisk.examples.minimal";
      android.displayName = "Obelisk Minimal Example";
      ios.bundleIdentifier = "systems.obsidian.obelisk.examples.minimal";


### PR DESCRIPTION
This is an attempt to update the docs of rhyolite with what I think is the more modern form for default.nix (pulled from a fresh obelisk scaffold) with the override for rhyolite.

I've tested in on a fresh obelisk scaffold project, as well as my codebase and it seems to work fine. 