### PR TITLE
Improve the types in rhyolite-email

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -49,6 +49,7 @@ This project's release branch is `master`. This log is written from the perspect
   * Narrow the type of `signWithKey` so that the input type matches the output's phantom type parameter.
   * Move `Rhyolite.Backend.Email` and `Rhyolite.Email` to `Rhyolite.Email` in the new `rhyolite-email` package.
     * Provide more error information in the interface for sending an email in `rhyolite-email`.
+    * The `EmailEnv` type has been changed to `EmailConfig`, which is a structured record type instead of a flat tuple.
   * Move `LargeObjectId` to `psql-simple-class`.
   * Remove the `Rhyolite.TH` module. Use `file-embed` instead.
   * Move `Rhyolite.Backend.EmailWorker` to `Rhyolite.DB.Groundhog.EmailWorker` in `groundhog-legacy`. Change the schema for `QueuedEmail` to contain a JSON blob of the `Mail` object instead of the rendered email bytestring. See the groundhog-legacy migration guide for more information.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -48,6 +48,7 @@ This project's release branch is `master`. This log is written from the perspect
   * Remove Data.MonoidMap. It has been moved to [monoid-map](https://github.com/obsidiansystems/monoid-map) and is now used as a dependency.
   * Narrow the type of `signWithKey` so that the input type matches the output's phantom type parameter.
   * Move `Rhyolite.Backend.Email` and `Rhyolite.Email` to `Rhyolite.Email` in the new `rhyolite-email` package.
+    * Provide more error information in the interface for sending an email in `rhyolite-email`.
   * Move `LargeObjectId` to `psql-simple-class`.
   * Remove the `Rhyolite.TH` module. Use `file-embed` instead.
   * Move `Rhyolite.Backend.EmailWorker` to `Rhyolite.DB.Groundhog.EmailWorker` in `groundhog-legacy`. Change the schema for `QueuedEmail` to contain a JSON blob of the `Mail` object instead of the rendered email bytestring. See the groundhog-legacy migration guide for more information.

--- a/email/src/Rhyolite/Email.hs
+++ b/email/src/Rhyolite/Email.hs
@@ -116,7 +116,7 @@ instance FromJSON EmailAuth
 -- authenticate with it.
 data EmailConfig = EmailConfig
   { _emailConfig_hostname :: HostName -- ^ E.g., "smtp.server.com"
-  , _emailConfig_port :: Word16
+  , _emailConfig_port :: PortNumber
   , _emailConfig_protocol :: SMTPProtocol
   , _emailConfig_emailAuth :: Maybe EmailAuth
   } deriving (Show, Eq, Generic)
@@ -134,7 +134,7 @@ sendEmail ee m = withSMTP ee $ HaskellNet.sendMail m
 withSMTP :: EmailConfig -> (SMTPConnection -> IO a) -> IO (Either EmailError a)
 withSMTP cfg send = do
   let hostname = _emailConfig_hostname cfg
-      port = fromIntegral $ _emailConfig_port cfg
+      port = _emailConfig_port cfg
       go conn = case _emailConfig_emailAuth cfg of
         Nothing -> Right <$> send conn
         Just (EmailAuth authType un pw) -> do

--- a/email/src/Rhyolite/Email.hs
+++ b/email/src/Rhyolite/Email.hs
@@ -60,8 +60,8 @@ import qualified Text.Blaze.Html5.Attributes as A
 
 -- | Errors that can arise while interacting with an SMTP server
 data EmailError
-   = EmailError_Connection Text
-   -- ^ An error occurred while trying to connect to the SMTP server
+   = EmailError_AuthFailed
+   -- ^ The SMTP server refused to authenticate
    | EmailError_Exception SMTPException
    -- ^ An error occurred while interacting with an SMTP server
   deriving (Generic, Show)
@@ -141,7 +141,7 @@ withSMTP cfg send = do
           loginResult <- authenticate authType (T.unpack un) (T.unpack pw) conn
           if loginResult
             then Right <$> send conn
-            else pure $ Left (EmailError_Connection "withSMTP: authenticate command failed")
+            else pure $ Left EmailError_AuthFailed
   er <- try $ case _emailConfig_protocol cfg of
     SMTPProtocol_Plain -> doSMTPPort hostname port go
     SMTPProtocol_STARTTLS -> doSMTPSTARTTLSWithSettings hostname (defaultSettingsSMTPSTARTTLS { sslPort = port }) go

--- a/groundhog-legacy/groundhog-legacy/README.md
+++ b/groundhog-legacy/groundhog-legacy/README.md
@@ -57,4 +57,8 @@ This module has been renamed to `Rhyolite.DB.Groundhog.Schema.Class` and moved t
 ### Rhyolite.Backend.EmailWorker
 This module has been renamed to `Rhyolite.DB.Groundhog.EmailWorker` and moved to this package.
 
+Some functions now require a `MonadIO` instance as well as a `MonadEmail` instance.
+
+The `EmailEnv` type has been changed to `EmailConfig` which is a record instead of a flat tuple.
+
 The `QueuedEmail` type has been changed in accordance with the changes to `HaskellNet-0.6`. In particular, rather than storing a `ByteString` of the rendered mail and JSON objects containing the sender and recipients, the `QueuedEmail` table now stores the entire `Network.Mail.Mime.Mail` object as JSON.  Going from the rendered email bytestring back to the `Mail` object requires parsing. It's recommended instead that you drain your email queue before migrating.

--- a/groundhog-legacy/groundhog-legacy/src/Rhyolite/DB/Groundhog/Email.hs
+++ b/groundhog-legacy/groundhog-legacy/src/Rhyolite/DB/Groundhog/Email.hs
@@ -13,4 +13,4 @@ import Rhyolite.Email
 import Control.Monad.Trans.Reader
 import Rhyolite.DB.Groundhog.TH
 
-deriveNewtypePersistBackend (\m -> [t| EmailT $m |]) (\m -> [t| ReaderT EmailEnv $m |]) 'EmailT 'unEmailT
+deriveNewtypePersistBackend (\m -> [t| EmailT $m |]) (\m -> [t| ReaderT EmailConfig $m |]) 'EmailT 'unEmailT


### PR DESCRIPTION
There are two major changes:
  * `sendEmail` and similar functions return error information if there
    is an issue with connecting to the SMTP server, or communicating
    with it.
  * `EmailEnv` type, which indicates how to find and authenticate with
    the server has been replaced with a more structured record type.