### PR TITLE
Add some helpful wrappers to rhyolite-beam-db

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,8 @@
 This project's release branch is `master`. This log is written from the perspective of the release branch: when changes hit `master`, they are considered released, and the date should reflect that release.
 
 ## Unreleased
+* Add helper types for beam code, namely `WrapColumnar` and `WrapNullable`.
+* Add beam orphan instances for some functor types, such as `Product` and `Proxy`.
 * Bump obelisk 1.0.0.0 and reflex-platform (0.9.2.0)
 * Add rhyolite-account-types and rhyolite-account-backend for use with beam-based rhyolite projects
   * Moved groundhog-legacy's `Rhyolite.Account` module to `Rhyolite.Account.Groundhog.Types`

--- a/beam/db/src/Rhyolite/DB/Beam.hs
+++ b/beam/db/src/Rhyolite/DB/Beam.hs
@@ -12,6 +12,8 @@ import Database.Beam.Postgres
 import Database.Beam.Postgres.Syntax
 import Database.PostgreSQL.Simple.Transaction
 
+import Rhyolite.DB.Beam.Orphans ()
+
 -- | Run beam SQL statements inside a Postgres Serializable Transaction
 withTransactionSerializableRunBeamPostgres :: (MonadIO m) => Connection -> Pg a -> m a
 withTransactionSerializableRunBeamPostgres dbConn = liftIO . withTransactionSerializable dbConn . runBeamPostgres dbConn

--- a/beam/db/src/Rhyolite/DB/Beam/Types.hs
+++ b/beam/db/src/Rhyolite/DB/Beam/Types.hs
@@ -1,6 +1,10 @@
 {-# language DeriveGeneric #-}
+{-# language FlexibleInstances #-}
+{-# language MultiParamTypeClasses #-}
 {-# language PolyKinds #-}
 {-# language RankNTypes #-}
+{-# language TemplateHaskell #-}
+{-# language TypeFamilies #-}
 {-|
    Description:
      Types and helpers for Beam that can be used in schemas and database interactions.
@@ -19,9 +23,13 @@ newtype WrapColumnar a f = WrapColumnar { unWrapColumnar :: Columnar f a }
 
 instance Beamable (WrapColumnar a)
 
+makeWrapped ''WrapColumnar
+
 -- | Used to decorate a beam thing like PrimaryKey with Nullable
 newtype WrapNullable k f = WrapNullable { unWrapNullable :: k (Nullable f) }
   deriving (Generic)
+
+makeWrapped ''WrapNullable
 
 -- | Useful in 'Rhyolite.Task.Beam.Task' for "no data" in payload or result.
 -- Every table has a subtable of type 'DummyTable'.

--- a/beam/db/src/Rhyolite/DB/Beam/Types.hs
+++ b/beam/db/src/Rhyolite/DB/Beam/Types.hs
@@ -1,0 +1,39 @@
+{-# language DeriveGeneric #-}
+{-# language PolyKinds #-}
+{-# language RankNTypes #-}
+{-|
+   Description:
+     Types and helpers for Beam that can be used in schemas and database interactions.
+-}
+module Rhyolite.DB.Beam.Types where
+
+import Control.Lens
+import Data.Proxy
+import Database.Beam
+import Rhyolite.DB.Beam.Orphans ()
+
+-- | Like "Columnar", but a newtype instead of a type family, and the arguments
+-- are in a more convenient order.
+newtype WrapColumnar a f = WrapColumnar { unWrapColumnar :: Columnar f a }
+  deriving (Generic)
+
+instance Beamable (WrapColumnar a)
+
+-- | Used to decorate a beam thing like PrimaryKey with Nullable
+newtype WrapNullable k f = WrapNullable { unWrapNullable :: k (Nullable f) }
+  deriving (Generic)
+
+-- | Useful in 'Rhyolite.Task.Beam.Task' for "no data" in payload or result.
+-- Every table has a subtable of type 'DummyTable'.
+type DummyTable = (Proxy :: k -> *)
+
+-- | Nicer name for 'Proxy' that explains what it's useful for in certain
+-- contexts: A phantom standing in for a null part of a schema.
+dummyTable :: forall k (x :: k). Proxy x
+dummyTable = Proxy
+
+-- | Every Beam table has a subtable of 'DummyTable'.
+dummyTableLens :: forall k x. Lens' (k x) (DummyTable x)
+dummyTableLens = lens
+  (\_ -> Proxy)
+  (\t _ -> t)

--- a/beam/orphans/LICENSE
+++ b/beam/orphans/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2021, Obsidian Systems LLC
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Obsidian Systems LLC nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/beam/orphans/rhyolite-beam-orphans.cabal
+++ b/beam/orphans/rhyolite-beam-orphans.cabal
@@ -1,7 +1,7 @@
 cabal-version:      2.4
-name:               rhyolite-beam-db
+name:               rhyolite-beam-orphans
 version:            0.1.0.0
-synopsis:           Beam database functions.
+synopsis:           Missing instances that have not yet been upstreamed to beam
 homepage:           https://github.com/obsidiansystems/rhyolite
 bug-reports:        https://github.com/obsidiansystems/rhyolite/issues
 license:            BSD-3-Clause
@@ -14,17 +14,11 @@ extra-source-files: README.md
 
 library
   exposed-modules:
-    Rhyolite.DB.Beam
-    Rhyolite.DB.Beam.Types
+    Rhyolite.DB.Beam.Orphans
 
   build-depends:
       base
-    , lens
-    , rhyolite-beam-orphans
     , beam-core
-    , beam-postgres
-    , postgresql-simple
-    , time
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/beam/orphans/src/Rhyolite/DB/Beam/Orphans.hs
+++ b/beam/orphans/src/Rhyolite/DB/Beam/Orphans.hs
@@ -1,0 +1,16 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# language TypeOperators #-}
+{-|
+   Description:
+     Types and helpers for Beam that can be used in schemas and database interactions.
+-}
+module Rhyolite.DB.Beam.Orphans where
+
+import Data.Functor.Product
+import Data.Proxy
+import Database.Beam
+import GHC.Generics
+
+instance Beamable Proxy
+instance (Beamable f, Beamable g) => Beamable (f :*: g)
+instance (Beamable f, Beamable g) => Beamable (Product f g)

--- a/default.nix
+++ b/default.nix
@@ -16,6 +16,7 @@ let
   rhyolitePackages = {
     rhyolite-backend = ./backend;
     rhyolite-beam-db = ./beam/db;
+    rhyolite-beam-orphans = ./beam/orphans;
     rhyolite-beam-task-worker-types = ./beam/task/types;
     rhyolite-beam-task-worker-backend = ./beam/task/backend;
     rhyolite-notify-listen = ./notify-listen/notify-listen;


### PR DESCRIPTION
First, there are many pre-existing functors that could usefully have
Beam instances that yet don't. So added is rhyolite-beam-orphans as a
staging area for upstreaming things to beam proper.

We also add `WrapColumnar` and `WrapNullable` classes which are useful
for passing table-like types as interface specifications. In this vein,
  we have also added a type alias for `Proxy`, namely `DummyTable`,
  because it has the useful property of being a 'sub-table' of every
  beam table type.