### PR TITLE
fix O(n) query handler in handlePersonalAuthMapQuery.

### DIFF
--- a/backend/rhyolite-backend.cabal
+++ b/backend/rhyolite-backend.cabal
@@ -21,6 +21,7 @@ library
     , lens
     , monoid-map
     , monoidal-containers
+    , patch
     , postgresql-simple
     , reflex
     , resource-pool

--- a/common/Rhyolite/App.hs
+++ b/common/Rhyolite/App.hs
@@ -43,6 +43,7 @@ import Data.These
 import Data.These.Combinators
 import Data.Typeable (Typeable)
 import Data.Vessel
+import Data.Vessel.Void
 import Data.Vessel.Internal (VSum(..))
 import Data.Witherable (Filterable(..))
 import GHC.Generics (Generic)
@@ -98,6 +99,7 @@ deriving instance PositivePart (g v) => PositivePart (IdentityV v g)
 deriving instance PositivePart (g f) => PositivePart (FlipAp f g)
 deriving instance (GCompare f, Has' PositivePart f (FlipAp g)) => PositivePart (Vessel f g)
 deriving instance (Ord k, PositivePart (f g)) => PositivePart (SubVessel k f g)
+instance PositivePart (VoidV x) where positivePart = const Nothing
 
 instance PositivePart a => PositivePart [a] where positivePart = composePositivePart
 instance PositivePart a => PositivePart (Maybe a) where positivePart = composePositivePart

--- a/common/Rhyolite/Vessel/App.hs
+++ b/common/Rhyolite/Vessel/App.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ConstraintKinds #-}
+
+module Rhyolite.Vessel.App where
+
+import Rhyolite.Vessel.Types
+import Rhyolite.Vessel.AuthenticatedV
+import Rhyolite.Api
+
+type RhyoliteAuthAppC app = HasRhyoliteAuth
+  (AuthCredential app)
+  (PublicV app)
+  (PrivateV app)
+  (PersonalV app)
+
+-- | optional class to help organise the types of a rhyolite authenticated app.
+class RhyoliteAuthAppC app => RhyoliteAuthApp app where
+  type AuthCredential app :: *
+
+  type PublicApi app :: (* -> *)
+  type PrivateApi app :: (* -> *)
+
+  type PrivateV app :: ((* -> *) -> *)
+  type PersonalV app :: ((* -> *) -> *)
+  type PublicV app :: ((* -> *) -> *)
+
+-- | The full view selector which has a public, private, and personal part.
+type FullAppV app = FullV (AuthCredential app) (PublicV app) (PrivateV app) (PersonalV app)
+
+-- | The full view selector from the point of view of a particular authenticated identity which
+-- may or may not be valid; the result of a query can fail.
+type FullAppAuthErrorV app = FullAuthErrorV (PublicV app) (PrivateV app) (PersonalV app)
+
+-- | The full view selector from the point of view of a particular authenticated identity which
+-- assumes that the identity is valid and so the query cannot fali.
+type FullAppAuthV app = AuthenticatedV (PublicV app) (PrivateV app) (PersonalV app)
+
+type FullApi app = ApiRequest (AuthCredential app) (PublicApi app) (PrivateApi app)
+type FullAuthApi app = ApiRequest () (PublicApi app) (PrivateApi app)

--- a/common/Rhyolite/Vessel/AuthMapV.hs
+++ b/common/Rhyolite/Vessel/AuthMapV.hs
@@ -61,6 +61,8 @@ deriving instance (Ord auth, Eq (view g), Eq (g (First (Maybe ())))) => Eq (Auth
 instance (Ord auth, ToJSON auth, ToJSON (g (First (Maybe ()))), ToJSON (view g)) => ToJSON (AuthMapV auth view g)
 instance (Ord auth, FromJSON auth, View view, FromJSON (g (First (Maybe ()))), FromJSON (view g)) => FromJSON (AuthMapV auth view g)
 
+deriving instance (Show (v f), Show (f (First (Maybe ()))), Show k) => Show (AuthMapV k v f)
+
 deriving instance
   ( Ord auth
   , Has' Semigroup (ErrorVK () v) (FlipAp g)

--- a/common/Rhyolite/Vessel/AuthenticatedV.hs
+++ b/common/Rhyolite/Vessel/AuthenticatedV.hs
@@ -34,6 +34,7 @@ import Data.Vessel.Path (Keyed(..))
 import GHC.Generics
 import Reflex.Query.Class
 import Data.Map.Monoidal (MonoidalMap)
+import Data.Monoid.DecidablyEmpty
 
 -- TODO Upstream a function that lets you change DMap keys monotonically
 -- while mutating the value so we don't have to do it here.
@@ -103,7 +104,7 @@ instance ArgDict c (AuthenticatedVKey public private personal) where
 -- | A functor-parametric container that has a public part and a private part.
 newtype AuthenticatedV public private personal g = AuthenticatedV
   { unAuthenticatedV :: Vessel (AuthenticatedVKey public private personal) g
-  } deriving (Generic, Eq, ToJSON, FromJSON, Semigroup, Monoid, Group, Additive, PositivePart)
+  } deriving (Generic, Eq, ToJSON, FromJSON, Semigroup, Monoid, Group, Additive, PositivePart, DecidablyEmpty)
 
 instance (View public, View private, View personal) => View (AuthenticatedV public private personal)
 

--- a/common/Rhyolite/Vessel/AuthenticatedV.hs
+++ b/common/Rhyolite/Vessel/AuthenticatedV.hs
@@ -166,7 +166,9 @@ handleAuthenticatedQuery
   -> (private Proxy -> m (private Identity))
   -- ^ The result of private queries is only available to authenticated identities
   -- but the result is the same for all of them.
-  -> (forall f g. (forall x. x -> f x -> g x)
+  -> ( forall f g.
+      ViewQueryResult f ~ g
+      => (forall x. x -> f x -> g x)
       -> personal (Compose (MonoidalMap user) f)
       -> m (personal (Compose (MonoidalMap user) g)))
   -- ^ The result of personal queries depends on the identity making the query

--- a/common/Rhyolite/Vessel/ErrorV/Internal.hs
+++ b/common/Rhyolite/Vessel/ErrorV/Internal.hs
@@ -148,6 +148,17 @@ observeErrorV (ErrorV v) = case lookupV ErrorVK_Error v of
     Nothing -> Right emptyV
     Just e -> Left e
 
+-- | Given an 'ErrorV' result, observe whether it is an error result
+-- or a result of the underlying view type.
+unsafeObserveErrorV
+  :: ErrorV e v f
+  -> (Maybe (f (First (Maybe e))), Maybe (v f))
+unsafeObserveErrorV (ErrorV v) =
+  let
+    err = fmap unSingleV $ lookupV ErrorVK_Error v
+  in (err, lookupV ErrorVK_View v)
+
+
 -- | A morphism that only cares about error results.
 unsafeProjectE
   :: ( EmptyView v

--- a/common/Rhyolite/Vessel/ErrorV/Internal.hs
+++ b/common/Rhyolite/Vessel/ErrorV/Internal.hs
@@ -18,6 +18,7 @@ import Data.Aeson.GADT.TH
 import Data.Constraint
 import Data.Constraint.Extras
 import Data.GADT.Compare
+import Data.GADT.Show
 import Data.Patch
 import Data.Semigroup
 import Data.Type.Equality
@@ -62,6 +63,13 @@ instance ArgDict c (ErrorVK err view) where
     ErrorVK_Error -> Dict
     ErrorVK_View -> Dict
 
+deriving instance Show (ErrorVK e v a)
+
+instance GShow (ErrorVK e v) where
+  gshowsPrec = showsPrec
+
+deriving instance (Show (v f), Show (f (First (Maybe e)))) => Show (ErrorV e v f)
+
 -- | A functor-parametric container which as a query will contain a value of the
 -- underlying view type and as a result may contain either an err value or a
 -- view result value.
@@ -92,17 +100,9 @@ instance
 instance
   ( Semigroup (v Identity)
   , View v
-  , QueryResult (v (Const ())) ~ v Identity
-  ) => Query (ErrorV err v (Const ())) where
-  type QueryResult (ErrorV err v (Const ())) = ErrorV err v Identity
-  crop (ErrorV s) (ErrorV r) = ErrorV $ crop s r
-
-instance
-  ( Semigroup (v Identity)
-  , View v
-  , QueryResult (v (Const SelectedCount)) ~ v Identity
-  ) => Query (ErrorV err v (Const SelectedCount)) where
-  type QueryResult (ErrorV err v (Const SelectedCount)) = ErrorV err v Identity
+  , QueryResult (v (Const g)) ~ v Identity
+  ) => Query (ErrorV err v (Const g)) where
+  type QueryResult (ErrorV err v (Const g)) = ErrorV err v Identity
   crop (ErrorV s) (ErrorV r) = ErrorV $ crop s r
 
 instance
@@ -148,8 +148,8 @@ observeErrorV (ErrorV v) = case lookupV ErrorVK_Error v of
     Nothing -> Right emptyV
     Just e -> Left e
 
--- | Given an 'ErrorV' result, observe whether it is an error result
--- or a result of the underlying view type.
+-- | Given an 'ErrorV' result, observe both error and result
+-- of the underlying view type.
 unsafeObserveErrorV
   :: ErrorV e v f
   -> (Maybe (f (First (Maybe e))), Maybe (v f))

--- a/common/Rhyolite/Vessel/Types.hs
+++ b/common/Rhyolite/Vessel/Types.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Rhyolite.Vessel.Types where
+
+import Data.Vessel.Class
+import Data.Functor.Identity
+import Data.Functor.Const
+import Data.Patch (Group)
+import Reflex.Query.Class
+
+import Rhyolite.Vessel.AuthenticatedV
+import Rhyolite.Vessel.ErrorV
+import Rhyolite.Vessel.AuthMapV
+
+type RhyoliteAuthViewC v =
+  ( View v
+  , Group (v (Const SelectedCount))
+  , Eq (v (Const SelectedCount))
+  , Semigroup (v Identity)
+  , QueryResult (v (Const SelectedCount)) ~ v Identity
+  , EmptyView v
+  )
+
+type HasRhyoliteAuth token publicV privateV personalV =
+  ( Ord token
+  , RhyoliteAuthViewC publicV
+  , RhyoliteAuthViewC privateV
+  , RhyoliteAuthViewC personalV
+  )
+
+-- | The full view selector which has a public, private, and personal part.
+type FullV token publicV privateV personalV = AuthenticatedV publicV (AuthMapV token privateV) (AuthMapV token personalV)
+
+-- | The full view selector from the point of view of a particular authenticated identity which
+-- may or may not be valid; the result of a query can fail.
+type FullAuthErrorV publicV privateV personalV = AuthenticatedV publicV (ErrorV () privateV) (ErrorV () personalV)

--- a/common/rhyolite-common.cabal
+++ b/common/rhyolite-common.cabal
@@ -57,6 +57,8 @@ library
     Rhyolite.Vessel.ErrorV
     Rhyolite.Vessel.ErrorV.Internal
     Rhyolite.Vessel.Path
+    Rhyolite.Vessel.Types
+    Rhyolite.Vessel.App
     Rhyolite.WebSocket
 
   reexported-modules: aeson-gadt-th:Data.Aeson.GADT.TH as Data.Aeson.GADT

--- a/default.nix
+++ b/default.nix
@@ -62,6 +62,7 @@ let
     push-notifications = repos.push-notifications;
     vessel = repos.vessel;
     dependent-sum-aeson-orphans = repos.dependent-sum-aeson-orphans;
+
   };
 
   # You can use these manually if you don’t want to use rhyolite.project.
@@ -101,6 +102,12 @@ let
       } {};
       HaskellNet = self.callHackage "HaskellNet" "0.6" {};
       HaskellNet-SSL = self.callHackage "HaskellNet-SSL" "0.3.4.4" {};
+
+      base-orphans = self.callHackageDirect {
+        pkg = "base-orphans";
+        ver = "0.8.6";
+        sha256 = "sha256:17hplm1mgw65jbszg5z4vqk4i24ilxv8mbszr3s8lhpll5naik26";
+      } {};
 
       # 'locale' is broken on nix darwin which is required by postgres 'initdb'
       rhyolite-beam-task-worker-backend = if pkgs.stdenv.hostPlatform.isDarwin

--- a/dep/monoid-map/github.json
+++ b/dep/monoid-map/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "obsidiansystems",
   "repo": "monoid-map",
-  "branch": "release/0.1.1.0",
+  "branch": "master",
   "private": false,
-  "rev": "afff9f55a8d73184971987ca06f6485e2ebe0fed",
-  "sha256": "1b7rqgcrnzcg0ykxnxvadq40v8dlkhynjd2rqkl1wa42xw28mlbb"
+  "rev": "16fa87520b8681d34c4f0558651e55d80aebc91f",
+  "sha256": "1z58fblajrvd5ygb0mzm6yxd2mmgg0v7krj8ck34zdfnwjj17dfc"
 }

--- a/dep/monoid-map/thunk.nix
+++ b/dep/monoid-map/thunk.nix
@@ -2,7 +2,7 @@
 let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
   if !fetchSubmodules && !private then builtins.fetchTarball {
     url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
-  } else (import <nixpkgs> {}).fetchFromGitHub {
+  } else (import "/nix/store/qjg458n31xk1l6lj26c3b871d4i4is98-source" {}).fetchFromGitHub {
     inherit owner repo rev sha256 fetchSubmodules private;
   };
   json = builtins.fromJSON (builtins.readFile ./github.json);

--- a/dep/vessel/github.json
+++ b/dep/vessel/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "obsidiansystems",
   "repo": "vessel",
-  "branch": "cg/path",
+  "branch": "polymorphic-viewmorphisms",
   "private": false,
-  "rev": "34cd53ffa39c9e13cb62b38bfdef3caa37d5797f",
-  "sha256": "0vk8b5n026dh7c7kjj4rzgbj993h9wmygrd8a2vb180c4wq3ppsr"
+  "rev": "82634e6f260e1206098a83fcd0361dd1c1cb9abb",
+  "sha256": "19cvz9f3wm70pralh8pys2m7hs8vdjpaxhigrvjrawm2r5v2047i"
 }

--- a/dep/vessel/github.json
+++ b/dep/vessel/github.json
@@ -3,6 +3,6 @@
   "repo": "vessel",
   "branch": "polymorphic-viewmorphisms",
   "private": false,
-  "rev": "9d2e51a021ebb064b2298de37e0c4910350b5841",
-  "sha256": "02qravqqkf00b400phrjglvyl0ggn752y8mh402y3j6nih87hyll"
+  "rev": "b61428df85f0befa90a8cbd18cb860ebded70e21",
+  "sha256": "0wnl0gvzv11ja8y3xhymdd99p00zprgs62m3q259pk7gr25hj1kh"
 }

--- a/dep/vessel/github.json
+++ b/dep/vessel/github.json
@@ -3,6 +3,6 @@
   "repo": "vessel",
   "branch": "polymorphic-viewmorphisms",
   "private": false,
-  "rev": "82634e6f260e1206098a83fcd0361dd1c1cb9abb",
-  "sha256": "19cvz9f3wm70pralh8pys2m7hs8vdjpaxhigrvjrawm2r5v2047i"
+  "rev": "9d2e51a021ebb064b2298de37e0c4910350b5841",
+  "sha256": "02qravqqkf00b400phrjglvyl0ggn752y8mh402y3j6nih87hyll"
 }

--- a/frontend/Rhyolite/Frontend/Auth.hs
+++ b/frontend/Rhyolite/Frontend/Auth.hs
@@ -8,7 +8,6 @@ module Rhyolite.Frontend.Auth where
 import Control.Category
 import Control.Monad.Fix
 import Data.Functor.Const
-import Data.Functor.Identity
 import Prelude hiding ((.), id)
 import Reflex
 
@@ -20,29 +19,50 @@ import Rhyolite.Vessel.Types
 
 -- | The type for app widgets at the top level of the app.
 -- Includes full Auth handling for queries and requests.
-type FullWidget t token publicApi privateApi publicV privateV personalV m =
-  (QueryT t (FullV token publicV privateV personalV (Const SelectedCount))
-    (RequesterT t (ApiRequest token publicApi privateApi) Identity m))
+type FullWidget token publicApi privateApi publicV privateV personalV =
+  RhyoliteWidget
+    (FullV token publicV privateV personalV (Const SelectedCount))
+    (ApiRequest token publicApi privateApi)
+
+type FullWidgetInternal token publicApi privateApi publicV privateV personalV t m =
+  RhyoliteWidgetInternal
+    (FullV token publicV privateV personalV (Const SelectedCount))
+    (ApiRequest token publicApi privateApi)
+    t m
 
 -- | The type for app widgets that have been specialized to a particular
 -- authenticated identity that may or may not be valid, and so the queries
 -- can fail.
-type AuthErrorWidget t token publicApi privateApi publicV privateV personalV m =
-  (QueryT t (FullAuthErrorV publicV privateV personalV (Const SelectedCount))
-    (RequesterT t (ApiRequest () publicApi privateApi) Identity m))
+type AuthErrorWidget token publicApi privateApi publicV privateV personalV =
+  RhyoliteWidget
+    (FullAuthErrorV publicV privateV personalV (Const SelectedCount))
+    (ApiRequest () publicApi privateApi)
+
+type AuthErrorWidgetInternal token publicApi privateApi publicV privateV personalV t m =
+  RhyoliteWidgetInternal
+    (FullAuthErrorV publicV privateV personalV (Const SelectedCount))
+    (ApiRequest () publicApi privateApi)
+    t m
 
 -- | The type for app widgets that have been specialized to a particular
 -- authenticated identity where authentication errors have already been handled
 -- so the queries cannot fail within this widget.
-type AuthWidget t token publicApi privateApi publicV privateV personalV m =
-  (QueryT t (AuthenticatedV publicV privateV personalV (Const SelectedCount))
-    (RequesterT t (ApiRequest () publicApi privateApi ) Identity m))
+type AuthWidget token publicApi privateApi publicV privateV personalV =
+  RhyoliteWidget
+    (AuthenticatedV publicV privateV personalV (Const SelectedCount))
+    (ApiRequest () publicApi privateApi )
+
+type AuthWidgetInternal token publicApi privateApi publicV privateV personalV t m =
+  RhyoliteWidgetInternal
+    (AuthenticatedV publicV privateV personalV (Const SelectedCount))
+    (ApiRequest () publicApi privateApi )
+    t m
 
 -- | Embeds a widget that uses a specific auth identity into a context where no auth identity is presumed.
 authenticatedWidget
   :: ( MonadFix m, PostBuild t m
      , HasRhyoliteAuth token publicV privateV personalV )
   => token
-  -> AuthErrorWidget t token publicApi privateApi publicV privateV personalV m a
-  -> FullWidget t token publicApi privateApi publicV privateV personalV m a
-authenticatedWidget token = unRhyoliteWidget . mapAuth token (mapAuthenticatedV id (authMapQueryMorphism token) (authMapQueryMorphism token))
+  -> AuthErrorWidget token publicApi privateApi publicV privateV personalV t m a
+  -> FullWidget token publicApi privateApi publicV privateV personalV t m a
+authenticatedWidget token = mapAuth token (mapAuthenticatedV id (authMapQueryMorphism token) (authMapQueryMorphism token)) . unRhyoliteWidget

--- a/frontend/Rhyolite/Frontend/Auth.hs
+++ b/frontend/Rhyolite/Frontend/Auth.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Rhyolite.Frontend.Auth where
+
+import Control.Category
+import Control.Monad.Fix
+import Data.Functor.Const
+import Data.Functor.Identity
+import Data.Semigroup
+import Prelude hiding ((.), id)
+import Reflex
+
+import Rhyolite.Api
+import Rhyolite.Frontend.App
+import Rhyolite.Vessel.AuthMapV
+import Rhyolite.Vessel.AuthenticatedV
+import Rhyolite.Vessel.Types
+
+-- | The type for app widgets at the top level of the app.
+-- Includes full Auth handling for queries and requests.
+type FullWidget t token publicApi privateApi publicV privateV personalV m =
+    (EventWriterT t (First (Maybe token))
+      (QueryT t (FullV token publicV privateV personalV (Const SelectedCount))
+        (RequesterT t (ApiRequest token publicApi privateApi) Identity m)))
+
+-- | The type for app widgets that have been specialized to a particular
+-- authenticated identity that may or may not be valid, and so the queries
+-- can fail.
+type AuthErrorAppWidget t token publicApi privateApi publicV privateV personalV m =
+  (EventWriterT t (First (Maybe token))
+      (QueryT t (FullAuthErrorV publicV privateV personalV (Const SelectedCount))
+        (RequesterT t (ApiRequest () publicApi privateApi) Identity m)))
+
+-- | The type for app widgets that have been specialized to a particular
+-- authenticated identity where authentication errors have already been handled
+-- so the queries cannot fail within this widget.
+type AuthAppWidget t token publicApi privateApi publicV privateV personalV m =
+    (EventWriterT t (First (Maybe token))
+      (QueryT t (AuthenticatedV publicV privateV personalV (Const SelectedCount))
+        (RequesterT t (ApiRequest () publicApi privateApi ) Identity m)))
+
+-- | Embeds a widget that uses a specific auth identity into a context where no auth identity is presumed.
+authenticatedWidget
+  :: ( MonadFix m, PostBuild t m
+     , HasRhyoliteAuth token publicV privateV personalV )
+  => token
+  -> QueryT t (FullAuthErrorV publicV privateV personalV (Const SelectedCount)) (RequesterT t (ApiRequest () publicApi privateApi) Identity m) a
+  -> QueryT t (FullV token publicV privateV personalV (Const SelectedCount)) (RequesterT t (ApiRequest token publicApi privateApi) Identity m) a
+authenticatedWidget token = unRhyoliteWidget . mapAuth token (mapAuthenticatedV id (authMapQueryMorphism token) (authMapQueryMorphism token))

--- a/frontend/Rhyolite/Frontend/Auth.hs
+++ b/frontend/Rhyolite/Frontend/Auth.hs
@@ -9,7 +9,6 @@ import Control.Category
 import Control.Monad.Fix
 import Data.Functor.Const
 import Data.Functor.Identity
-import Data.Semigroup
 import Prelude hiding ((.), id)
 import Reflex
 
@@ -22,31 +21,28 @@ import Rhyolite.Vessel.Types
 -- | The type for app widgets at the top level of the app.
 -- Includes full Auth handling for queries and requests.
 type FullWidget t token publicApi privateApi publicV privateV personalV m =
-    (EventWriterT t (First (Maybe token))
-      (QueryT t (FullV token publicV privateV personalV (Const SelectedCount))
-        (RequesterT t (ApiRequest token publicApi privateApi) Identity m)))
+  (QueryT t (FullV token publicV privateV personalV (Const SelectedCount))
+    (RequesterT t (ApiRequest token publicApi privateApi) Identity m))
 
 -- | The type for app widgets that have been specialized to a particular
 -- authenticated identity that may or may not be valid, and so the queries
 -- can fail.
-type AuthErrorAppWidget t token publicApi privateApi publicV privateV personalV m =
-  (EventWriterT t (First (Maybe token))
-      (QueryT t (FullAuthErrorV publicV privateV personalV (Const SelectedCount))
-        (RequesterT t (ApiRequest () publicApi privateApi) Identity m)))
+type AuthErrorWidget t token publicApi privateApi publicV privateV personalV m =
+  (QueryT t (FullAuthErrorV publicV privateV personalV (Const SelectedCount))
+    (RequesterT t (ApiRequest () publicApi privateApi) Identity m))
 
 -- | The type for app widgets that have been specialized to a particular
 -- authenticated identity where authentication errors have already been handled
 -- so the queries cannot fail within this widget.
-type AuthAppWidget t token publicApi privateApi publicV privateV personalV m =
-    (EventWriterT t (First (Maybe token))
-      (QueryT t (AuthenticatedV publicV privateV personalV (Const SelectedCount))
-        (RequesterT t (ApiRequest () publicApi privateApi ) Identity m)))
+type AuthWidget t token publicApi privateApi publicV privateV personalV m =
+  (QueryT t (AuthenticatedV publicV privateV personalV (Const SelectedCount))
+    (RequesterT t (ApiRequest () publicApi privateApi ) Identity m))
 
 -- | Embeds a widget that uses a specific auth identity into a context where no auth identity is presumed.
 authenticatedWidget
   :: ( MonadFix m, PostBuild t m
      , HasRhyoliteAuth token publicV privateV personalV )
   => token
-  -> QueryT t (FullAuthErrorV publicV privateV personalV (Const SelectedCount)) (RequesterT t (ApiRequest () publicApi privateApi) Identity m) a
-  -> QueryT t (FullV token publicV privateV personalV (Const SelectedCount)) (RequesterT t (ApiRequest token publicApi privateApi) Identity m) a
+  -> AuthErrorWidget t token publicApi privateApi publicV privateV personalV m a
+  -> FullWidget t token publicApi privateApi publicV privateV personalV m a
 authenticatedWidget token = unRhyoliteWidget . mapAuth token (mapAuthenticatedV id (authMapQueryMorphism token) (authMapQueryMorphism token))

--- a/frontend/Rhyolite/Frontend/Auth/App.hs
+++ b/frontend/Rhyolite/Frontend/Auth/App.hs
@@ -7,16 +7,33 @@ import qualified Rhyolite.Frontend.Auth as Base
 import Rhyolite.Vessel.App as X
 import Control.Monad.Fix
 import Reflex
-import Data.Functor.Const
-import Data.Functor.Identity
 
+
+-- | The type for app widgets at the top level of the app.
+-- Includes full Auth handling for queries and requests.
+type FullAppWidget t app m =
+  Base.FullWidget t (AuthCredential app) (PublicApi app) (PrivateApi app) (PublicV app) (PrivateV app) (PersonalV app) m
+
+-- | The type for app widgets that have been specialized to a particular
+-- authenticated identity that may or may not be valid, and so the queries
+-- can fail.
+type AuthErrorAppWidget t app m =
+  Base.AuthErrorWidget t (AuthCredential app) (PublicApi app) (PrivateApi app) (PublicV app) (PrivateV app) (PersonalV app) m
+
+-- | The type for app widgets that have been specialized to a particular
+-- authenticated identity where authentication errors have already been handled
+-- so the queries cannot fail within this widget.
+type AuthAppWidget t app m =
+  Base.AuthWidget t (AuthCredential app) (PublicApi app) (PrivateApi app) (PublicV app) (PrivateV app) (PersonalV app) m
 
 -- | Embeds a widget that uses a specific auth identity into a context where no auth identity is presumed.
 authenticatedWidget
   :: ( MonadFix m, PostBuild t m
      , RhyoliteAuthApp app )
   => proxy app
-  -> (AuthCredential app)
-  -> QueryT t (FullAppAuthErrorV app (Const SelectedCount)) (RequesterT t (FullAuthApi app) Identity m) a
-  -> QueryT t (FullAppV app (Const SelectedCount)) (RequesterT t (FullApi app) Identity m) a
+  -> AuthCredential app
+  -> AuthErrorAppWidget t app m a
+  -> FullAppWidget t app m a
 authenticatedWidget _ = Base.authenticatedWidget
+
+

--- a/frontend/Rhyolite/Frontend/Auth/App.hs
+++ b/frontend/Rhyolite/Frontend/Auth/App.hs
@@ -1,0 +1,22 @@
+module Rhyolite.Frontend.Auth.App
+  ( module Rhyolite.Frontend.Auth.App
+  , module X
+  ) where
+
+import qualified Rhyolite.Frontend.Auth as Base
+import Rhyolite.Vessel.App as X
+import Control.Monad.Fix
+import Reflex
+import Data.Functor.Const
+import Data.Functor.Identity
+
+
+-- | Embeds a widget that uses a specific auth identity into a context where no auth identity is presumed.
+authenticatedWidget
+  :: ( MonadFix m, PostBuild t m
+     , RhyoliteAuthApp app )
+  => proxy app
+  -> (AuthCredential app)
+  -> QueryT t (FullAppAuthErrorV app (Const SelectedCount)) (RequesterT t (FullAuthApi app) Identity m) a
+  -> QueryT t (FullAppV app (Const SelectedCount)) (RequesterT t (FullApi app) Identity m) a
+authenticatedWidget _ = Base.authenticatedWidget

--- a/frontend/Rhyolite/Frontend/Auth/App.hs
+++ b/frontend/Rhyolite/Frontend/Auth/App.hs
@@ -11,20 +11,20 @@ import Reflex
 
 -- | The type for app widgets at the top level of the app.
 -- Includes full Auth handling for queries and requests.
-type FullAppWidget t app m =
-  Base.FullWidget t (AuthCredential app) (PublicApi app) (PrivateApi app) (PublicV app) (PrivateV app) (PersonalV app) m
+type FullAppWidget app =
+  Base.FullWidget (AuthCredential app) (PublicApi app) (PrivateApi app) (PublicV app) (PrivateV app) (PersonalV app)
 
 -- | The type for app widgets that have been specialized to a particular
 -- authenticated identity that may or may not be valid, and so the queries
 -- can fail.
-type AuthErrorAppWidget t app m =
-  Base.AuthErrorWidget t (AuthCredential app) (PublicApi app) (PrivateApi app) (PublicV app) (PrivateV app) (PersonalV app) m
+type AuthErrorAppWidget app =
+  Base.AuthErrorWidget (AuthCredential app) (PublicApi app) (PrivateApi app) (PublicV app) (PrivateV app) (PersonalV app)
 
 -- | The type for app widgets that have been specialized to a particular
 -- authenticated identity where authentication errors have already been handled
 -- so the queries cannot fail within this widget.
-type AuthAppWidget t app m =
-  Base.AuthWidget t (AuthCredential app) (PublicApi app) (PrivateApi app) (PublicV app) (PrivateV app) (PersonalV app) m
+type AuthAppWidget app =
+  Base.AuthWidget (AuthCredential app) (PublicApi app) (PrivateApi app) (PublicV app) (PrivateV app) (PersonalV app)
 
 -- | Embeds a widget that uses a specific auth identity into a context where no auth identity is presumed.
 authenticatedWidget
@@ -32,8 +32,8 @@ authenticatedWidget
      , RhyoliteAuthApp app )
   => proxy app
   -> AuthCredential app
-  -> AuthErrorAppWidget t app m a
-  -> FullAppWidget t app m a
+  -> AuthErrorAppWidget app t m a
+  -> FullAppWidget app t m a
 authenticatedWidget _ = Base.authenticatedWidget
 
 

--- a/frontend/rhyolite-frontend.cabal
+++ b/frontend/rhyolite-frontend.cabal
@@ -52,6 +52,8 @@ library
   exposed-modules:
     Rhyolite.Frontend.App
     Rhyolite.Frontend.Cookie
+    Rhyolite.Frontend.Auth
+    Rhyolite.Frontend.Auth.App
 
   ghc-options:
     -Wall -fno-warn-unused-do-bind -fwarn-tabs -funbox-strict-fields


### PR DESCRIPTION
old version ran query handler for every token in the query.  new version
calls it only once, with users in the view rather than a separate argument.

As a general rule, any use of `traverse` in handlers is suspect for
this reason.