### PR TITLE
Add missing quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ Rhyolite provides:
    { system ? builtins.currentSystem, obelisk ? import ./.obelisk/impl {
      inherit system;
      iosSdkVersion = "13.2";
- 
+
      # You must accept the Android Software Development Kit License Agreement at
      # https://developer.android.com/studio/terms in order to build Android apps.
      # Uncomment and set this to `true` to indicate your acceptance:
      # config.android_sdk.accept_license = false;
- 
+
      # In order to use Let's Encrypt for HTTPS deployments you must accept
      # their terms of service at https://letsencrypt.org/repository/.
      # Uncomment and set this to `true` to indicate your acceptance:
@@ -41,7 +41,7 @@ Rhyolite provides:
    } }:
    with obelisk;
    project ./. ({ pkgs, hackGet, ... }@args: {
- 
+
      overrides = pkgs.lib.composeExtensions
        (pkgs.callPackage (hackGet ./dep/rhyolite) args).haskellOverrides
        (self: super:
@@ -49,7 +49,7 @@ Rhyolite provides:
          {
            # Your custom overrides go here.
          });
- 
+
      android.applicationId = "systems.obsidian.obelisk.examples.minimal";
      android.displayName = "Obelisk Minimal Example";
      ios.bundleIdentifier = "systems.obsidian.obelisk.examples.minimal";
@@ -96,5 +96,5 @@ You can use `nix-shell -A proj.shells.ghc` to enter a shell from which you can b
 Because of the inter-related nature of these packages, `rhyolite-test-suite` tests that all of them can be built against one another. To test, run:
 
 ```bash
-nix-shell -A proj.shells.ghc --run cabal build test
+nix-shell -A proj.shells.ghc --run "cabal build test"
 ```


### PR DESCRIPTION
```shell
> nix-shell -A proj.shells.ghc --run cabal build test
error: getting status of '/home/alexfmpe/repos/rhyolite/build': No such file or directory
```