### PR TITLE
Fix current_timestamp_

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 This project's release branch is `master`. This log is written from the perspective of the release branch: when changes hit `master`, they are considered released, and the date should reflect that release.
 
 ## Unreleased
+* Fix `Rhyolite.DB.Beam.current_timestamp_` for PostgreSQL server instances whose time zone is *not* set to UTC.
 * Add helper types for beam code, namely `WrapColumnar` and `WrapNullable`.
 * Add beam orphan instances for some functor types, such as `Product` and `Proxy`.
 * Bump obelisk 1.0.0.0 and reflex-platform (0.9.2.0)

--- a/beam/db/src/Rhyolite/DB/Beam.hs
+++ b/beam/db/src/Rhyolite/DB/Beam.hs
@@ -20,4 +20,21 @@ withTransactionSerializableRunBeamPostgres dbConn = liftIO . withTransactionSeri
 
 -- | Postgres @current_timestamp()@ function. Returns the server's timestamp
 current_timestamp_ :: QExpr Postgres s UTCTime
-current_timestamp_ = QExpr (\_ -> PgExpressionSyntax (emit "current_timestamp at time zone 'UTC'"))
+-- Note: Previously we used the SQL expression @current_timestamp at time zone 'UTC'@
+--       here instead of @current_timestamp@.
+--       This caused a bug because this expression returns the current UTC time
+--       but without any time zone information; ie. the value would have the type
+--       @TIMESTAMP WITHOUT TIME ZONE@. When a value of this type is inserted
+--       into a column of type @TIMESTAMP WITH TIME ZONE@ it is cast into a value
+--       of the latter type by assuming the time zone is whatever the Postgres
+--       server is configured to use. This caused wrong timestamps to be inserted
+--       for all Postgres server instances whose time zone was not configured to
+--       be UTC.
+--       The type of the expression @current_timestamp@ is @TIMESTAMP WITH TIME ZONE@,
+--       which Postgres internally converts into a UTC timestamp which it stores.
+--       When this is retrieved from the database, Postgres read the stored UTC
+--       timestamp and returns the timestamp string using whatever time zone the
+--       server is configured to use. This string is deserialized into a 'UTCTime'
+--       (by 'postgresql-simple') by looking at the returned time zone offset and
+--       adjusting to UTC.
+current_timestamp_ = QExpr (\_ -> PgExpressionSyntax (emit "current_timestamp"))


### PR DESCRIPTION
The type of the Postgres expression `current_timestamp at time zone 'UTC'` is `TIMESTAMP WITHOUT TIME ZONE`. Consequently, if we attempt to store this in a column of type `TIMESTAMP WITH TIME ZONE` then Postgres will cast this `TIMESTAMP WITHOUT TIME ZONE`-value into a `TIMESTAMP WITH TIME ZONE` *using the time zone configured for the Postgres instance in question*. This results in `current_timestamp at time zone 'UTC'` being wrong for all Postgres instances running with a non-UTC time zone (ie. most).

Note that Postgres internally stores a value of type `TIMESTAMP WITH TIME ZONE` as a UTC timestamp. Ie. it does _not_ store the time zone component anywhere -- a timestamp with a time zone component is simply converted to UTC and then stored. So when `current_timestamp` returns e.g. `2022-08-08 11:59:35.958693+02`, Postgres will correctly convert this to the UTC time `2022-08-08 09:59:35.958693` -- whereas storing `2022-08-08 09:59:35.958693` in the same column would be cast to UTC+2 (`2022-08-08 09:59:35.958693+02`) and thus be two hours too early.

## Example

```psql
psql (11.11)
Type "help" for help.

postgres=# CREATE TABLE test_table (time TIMESTAMP WITH TIME ZONE);
CREATE TABLE
postgres=# select current_timestamp;
       current_timestamp       
-------------------------------
 2022-08-09 12:22:31.430855+02
(1 row)

postgres=# select current_timestamp at time zone 'UTC';
         timezone          
---------------------------
 2022-08-09 10:22:36.10837
(1 row)

postgres=# INSERT INTO test_table VALUES (current_timestamp at time zone 'UTC'); 
INSERT 0 1
postgres=# SELECT * FROM test_table;
             time              
-------------------------------
 2022-08-09 10:22:52.618104+02
(1 row)
```

