### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ result-*
 .attr-cache
 tags
 TAGS
+beam/task/backend/psql-test*


### PR DESCRIPTION
I had a ton of leftovers laying around created by https://github.com/obsidiansystems/rhyolite/blob/151649c516061dc766d46b526aba068274f7e0e6/beam/task/backend/test/Test.hs#L51
That could probably use one of the bracketed temp dir utils, but I guess even in that case we wouldn't want these dirs polluting git status, etc.