### PR TITLE
Fix Cabal Definitions

### DIFF
--- a/beam/db/rhyolite-beam-db.cabal
+++ b/beam/db/rhyolite-beam-db.cabal
@@ -10,7 +10,6 @@ author:             Obsidian Systems LLC
 maintainer:         maintainer@obsidian.systems
 copyright:          2021 Obsidian Systems LLC
 category:           Web
-extra-source-files: README.md
 
 library
   exposed-modules:

--- a/beam/orphans/rhyolite-beam-orphans.cabal
+++ b/beam/orphans/rhyolite-beam-orphans.cabal
@@ -10,7 +10,6 @@ author:             Obsidian Systems LLC
 maintainer:         maintainer@obsidian.systems
 copyright:          2021 Obsidian Systems LLC
 category:           Web
-extra-source-files: README.md
 
 library
   exposed-modules:

--- a/beam/task/backend/rhyolite-beam-task-worker-backend.cabal
+++ b/beam/task/backend/rhyolite-beam-task-worker-backend.cabal
@@ -10,7 +10,6 @@ author:             Obsidian Systems LLC
 maintainer:         maintainer@obsidian.systems
 copyright:          2021 Obsidian Systems LLC
 category:           Web
-extra-source-files: README.md
 
 library
   exposed-modules:

--- a/beam/task/types/rhyolite-beam-task-worker-types.cabal
+++ b/beam/task/types/rhyolite-beam-task-worker-types.cabal
@@ -10,7 +10,6 @@ author:             Obsidian Systems LLC
 maintainer:         maintainer@obsidian.systems
 copyright:          2021 Obsidian Systems LLC
 category:           Web
-extra-source-files: README.md
 
 library
   exposed-modules:

--- a/signed-data/signed-data-clientsession/signed-data-clientsession.cabal
+++ b/signed-data/signed-data-clientsession/signed-data-clientsession.cabal
@@ -13,7 +13,6 @@ author:             Obsidian Systems LLC
 maintainer:         maintainer@obsidian.systems
 copyright:          2021 Obsidian Systems LLC
 category:           Data
-extra-source-files: CHANGELOG.md
 
 library
   exposed-modules:  Data.Signed.ClientSession


### PR DESCRIPTION
`extra-source-files` needs to actually have that file within the folder, if it's not within the folder cabal fails to solve completely, since it's missing files from the repo.