### PR TITLE
Make authentication easier to use and fix some things about ErrorV

### DIFF
--- a/common/Rhyolite/Vessel/AuthenticatedV.hs
+++ b/common/Rhyolite/Vessel/AuthenticatedV.hs
@@ -18,7 +18,6 @@
 {-# LANGUAGE RankNTypes #-}
 module Rhyolite.Vessel.AuthenticatedV where
 
-import Control.Applicative
 import Control.Monad
 import Data.Aeson
 import Data.Aeson.GADT.TH
@@ -33,7 +32,6 @@ import Data.Vessel
 import Data.Vessel.Vessel
 import Data.Semigroup
 import Data.Semigroup.Commutative
-import Data.Vessel.Path (Keyed(..))
 import GHC.Generics
 import Reflex.Query.Class
 import Data.Map.Monoidal (MonoidalMap)
@@ -54,7 +52,6 @@ import Control.Applicative (Alternative)
 import Prelude hiding ((.), id)
 import Control.Category
 import Data.Vessel.ViewMorphism (ViewQueryResult, ViewMorphism(..), ViewHalfMorphism(..))
-import Data.Vessel.Vessel (vessel)
 import Data.Bifoldable
 
 -- TODO upstream this instance
@@ -173,11 +170,8 @@ handleAuthenticatedQuery
   -> (private Proxy -> m (private Identity))
   -- ^ The result of private queries is only available to authenticated identities
   -- but the result is the same for all of them.
-  -> ( forall f g.
-      ViewQueryResult f ~ g
-      => (forall x. x -> f x -> g x)
-      -> personal (Compose (MonoidalMap user) f)
-      -> m (personal (Compose (MonoidalMap user) g)))
+  -> ( personal (Compose (MonoidalMap user) Proxy)
+      -> m (personal (Compose (MonoidalMap user) Identity)))
   -- ^ The result of personal queries depends on the identity making the query
   -> AuthenticatedV public (AuthMapV token private) (AuthMapV token personal) Proxy
   -> m (AuthenticatedV public (AuthMapV token private) (AuthMapV token personal) Identity)
@@ -383,6 +377,8 @@ disperseAuthenticatedErrorV ::
   ( View publicV , Semigroup (publicV Identity)
   , EmptyView privateV , Semigroup (privateV Identity)
   , EmptyView personalV , Semigroup (personalV Identity)
+  , Num x, Semigroup x, Semigroup (privateV (Const x))
+  , Semigroup (personalV (Const x))
   )
   => QueryMorphism
     (ErrorV () (AuthenticatedV publicV privateV personalV) (Const x))
@@ -390,10 +386,10 @@ disperseAuthenticatedErrorV ::
 disperseAuthenticatedErrorV = QueryMorphism
   (maybe emptyV (runIdentity . traverseAuthenticatedV
       pure
-      (pure . liftErrorV)
-      (pure . liftErrorV))
+      (pure . queryErrorVConst)
+      (pure . queryErrorVConst))
     . snd . unsafeObserveErrorV)
-  (bifoldMap @(,) (maybe emptyV failureErrorV . (=<<) (getFirst . runIdentity)) liftErrorV
+  (bifoldMap @(,) (maybe emptyV failureErrorV . (=<<) (getFirst . runIdentity)) successErrorV
     . traverseAuthenticatedV
       ((,) Nothing)
       (fmap (maybe emptyV id) . unsafeObserveErrorV)

--- a/common/Rhyolite/Vessel/ErrorV/Internal.hs
+++ b/common/Rhyolite/Vessel/ErrorV/Internal.hs
@@ -167,9 +167,9 @@ observeErrorV (ErrorV v) = case lookupV ErrorVK_Error v of
     Just e -> Left e
 
 -- | A 'Path' which abstracts over constructing the query and observing the result.
-errorV :: (Semigroup (v Proxy), EmptyView v)
-       => Path (v Proxy) (ErrorV e v Proxy) (ErrorV e v Identity) (Either e (v Identity))
-errorV = Path { _path_to = queryErrorV, _path_from = Just . observeErrorV }
+errorV :: (Semigroup (v (Const x)), EmptyView v, Num x, Semigroup x)
+       => Path (v (Const x)) (ErrorV e v (Const x)) (ErrorV e v Identity) (Either e (v Identity))
+errorV = Path { _path_to = queryErrorVConst, _path_from = Just . observeErrorV }
 
 -- | Given an 'ErrorV' result, observe both error and result
 -- of the underlying view type.

--- a/common/Rhyolite/Vessel/ErrorV/Internal.hs
+++ b/common/Rhyolite/Vessel/ErrorV/Internal.hs
@@ -166,6 +166,11 @@ observeErrorV (ErrorV v) = case lookupV ErrorVK_Error v of
     Nothing -> Right emptyV
     Just e -> Left e
 
+-- | A 'Path' which abstracts over constructing the query and observing the result.
+errorV :: (Semigroup (v Proxy), EmptyView v)
+       => Path (v Proxy) (ErrorV e v Proxy) (ErrorV e v Identity) (Either e (v Identity))
+errorV = Path { _path_to = queryErrorV, _path_from = Just . observeErrorV }
+
 -- | Given an 'ErrorV' result, observe both error and result
 -- of the underlying view type.
 unsafeObserveErrorV

--- a/common/Rhyolite/Vessel/ErrorV/Internal.hs
+++ b/common/Rhyolite/Vessel/ErrorV/Internal.hs
@@ -164,7 +164,7 @@ observeErrorV (ErrorV v) = case lookupV ErrorVK_Error v of
     Just e -> Just (Left e)
 
 -- | A 'Path' which abstracts over constructing the query and observing the result.
-errorV :: (Semigroup (v (Const x)), EmptyView v, Num x, Semigroup x)
+errorV :: (Semigroup (v (Const x)), View v, Num x, Semigroup x)
        => Path (v (Const x)) (ErrorV e v (Const x)) (ErrorV e v Identity) (Either e (v Identity))
 errorV = Path { _path_to = queryErrorVConst, _path_from = observeErrorV }
 

--- a/common/Rhyolite/Vessel/ErrorV/Internal.hs
+++ b/common/Rhyolite/Vessel/ErrorV/Internal.hs
@@ -8,6 +8,7 @@
 {-# Language LambdaCase #-}
 {-# Language MultiParamTypeClasses #-}
 {-# Language PolyKinds #-}
+{-# Language RankNTypes #-}
 {-# Language StandaloneDeriving #-}
 {-# Language TemplateHaskell #-}
 {-# Language TypeFamilies #-}
@@ -122,9 +123,17 @@ instance
   type QueryResult (ErrorV err v (Compose c g)) = ErrorV err v (Compose c (VesselLeafWrapper (QueryResult (Vessel (ErrorVK err v) g))))
   crop (ErrorV s) (ErrorV r) = ErrorV $ crop s r
 
+-- | Construct a query that registers interest in both the success and error parts of an ErrorV.
+queryErrorV :: (View v, Semigroup (v Proxy)) => v Proxy -> ErrorV e v Proxy
+queryErrorV v = ErrorV (singletonV ErrorVK_View v <> singletonV ErrorVK_Error (SingleV Proxy))
+
+-- | Construct a query that registers interest in both the success and error parts of an ErrorV.
+queryErrorVConst :: (View v, Num x, Semigroup x, Semigroup (v (Const x))) => v (Const x) -> ErrorV e v (Const x)
+queryErrorVConst v = ErrorV (singletonV ErrorVK_View v <> singletonV ErrorVK_Error (SingleV (Const 1)))
+
 -- | The error part of the view will never be present
-liftErrorV :: View v => v g -> ErrorV e v g
-liftErrorV = ErrorV . singletonV ErrorVK_View
+successErrorV :: View v => v Identity -> ErrorV e v Identity
+successErrorV = ErrorV . singletonV ErrorVK_View
 
 -- | The successful part of the view will never be present
 failureErrorV :: e -> ErrorV e v Identity
@@ -141,7 +150,7 @@ buildErrorV f (ErrorV v) = case lookupV ErrorVK_View v of
   Nothing -> pure (ErrorV emptyV)
   Just v' -> f v' >>= \case
     Left err -> pure $ failureErrorV err
-    Right val -> pure $ liftErrorV val
+    Right val -> pure $ successErrorV val
 
 -- | Given an 'ErrorV' result, observe whether it is an error result
 -- or a result of the underlying view type.
@@ -166,29 +175,3 @@ unsafeObserveErrorV (ErrorV v) =
   let
     err = fmap unSingleV $ lookupV ErrorVK_Error v
   in (err, lookupV ErrorVK_View v)
-
-
--- | A morphism that only cares about error results.
-unsafeProjectE
-  :: ( EmptyView v
-     )
-  => QueryMorphism
-       ()
-       (ErrorV () v (Const SelectedCount))
-unsafeProjectE = QueryMorphism
-  { _queryMorphism_mapQuery = const (liftErrorV emptyV)
-  , _queryMorphism_mapQueryResult = const ()
-  }
-
--- | A morphism that only cares about successful results.
-unsafeProjectV
-  :: (EmptyView v, QueryResult (v (Const SelectedCount)) ~ v Identity)
-  => QueryMorphism
-       (v (Const SelectedCount))
-       (ErrorV () v (Const SelectedCount))
-unsafeProjectV = QueryMorphism
-  { _queryMorphism_mapQuery = liftErrorV
-  , _queryMorphism_mapQueryResult = \r -> case observeErrorV r of
-      Left _ -> emptyV
-      Right r' -> r'
-  }


### PR DESCRIPTION
The forced polymorphism in handlePersonalAuthMapQuery was preventing use of ErrorV for handling authorization failures (because its operations are intentionally monomorphic).

liftErrorV was not a good primitive to make queries, it would have been fine for reporting success, but did not explicitly register interest in the error part. Because of that, cropV would have quietly deleted the errors from the view. I'd be surprised if anything using this managed to avoid this pitfall.

As such, liftErrorV has been replaced by two new primitives: queryErrorV for registering interest in a view wrapped in ErrorV, and successErrorV for constructing a successful Identity view.

I also removed unsafeProjectE / unsafeProjectV from ErrorV rather than reworking them because the things they did were not entirely sensible to begin with:
* unsafeProjectE was requesting only errors from the backend, but then discarding those errors from the corresponding view on the way back. If you want that, you ought to avoid registering interest in the ErrorV in the first place, rather than making the backend work to discover that there's an error you're going to ignore.
* unsafeProjectV was treating failures the same way as lag (which is maybe on a rare occasion something you'd want, but let's not encourage it).